### PR TITLE
feat: 글 작성 기능 추가

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/DataLoader.java
+++ b/backend/src/main/java/com/wooteco/nolto/DataLoader.java
@@ -1,5 +1,9 @@
 package com.wooteco.nolto;
 
+import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.feed.domain.FeedRepository;
+import com.wooteco.nolto.feed.domain.Step;
+import com.wooteco.nolto.feed.ui.dto.FeedResponse;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
 import lombok.AllArgsConstructor;
@@ -7,6 +11,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -16,11 +21,13 @@ import java.util.List;
 public class DataLoader implements ApplicationRunner {
 
     private UserRepository userRepository;
+    private FeedRepository feedRepository;
 
     @Override
     public void run(ApplicationArguments args) {
+        User mickey = new User(null, "user1@email.com", "user1", "미키", new ArrayList<>(), Collections.emptyList());
         List<User> users = Arrays.asList(
-                new User(null, "user1@email.com", "user1", "미키", Collections.emptyList(), Collections.emptyList()),
+                mickey,
                 new User(null, "user2@email.com", "user2", "아마찌", Collections.emptyList(), Collections.emptyList()),
                 new User(null, "user3@email.com", "user3", "지그", Collections.emptyList(), Collections.emptyList()),
                 new User(null, "user4@email.com", "user4", "포모", Collections.emptyList(), Collections.emptyList()),
@@ -28,5 +35,10 @@ public class DataLoader implements ApplicationRunner {
                 new User(null, "user6@email.com", "user6", "찰리", Collections.emptyList(), Collections.emptyList())
         );
         userRepository.saveAll(users);
+
+        Feed feed1 = new Feed(new ArrayList<>(), "title1", "content1", Step.PROGRESS, true, "", "", "").writtenBy(mickey);
+        Feed feed2 = new Feed(new ArrayList<>(), "title2", "content2", Step.COMPLETE, false, "", "http://www.jofilm.com", "").writtenBy(mickey);
+        feedRepository.save(feed1);
+        feedRepository.save(feed2);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -1,0 +1,22 @@
+package com.wooteco.nolto.feed.application;
+
+import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.feed.domain.FeedRepository;
+import com.wooteco.nolto.feed.ui.dto.FeedRequest;
+import com.wooteco.nolto.feed.ui.dto.FeedResponse;
+import com.wooteco.nolto.user.domain.User;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@AllArgsConstructor
+@Service
+public class FeedService {
+
+    private final FeedRepository feedRepository;
+
+    public FeedResponse create(User user, FeedRequest request) {
+        Feed feed = request.toEntity().writtenBy(user);
+        Feed savedFeed = feedRepository.save(feed);
+        return FeedResponse.of(savedFeed);
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
@@ -9,7 +9,9 @@ import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor
@@ -51,4 +53,39 @@ public class Feed {
 
     @OneToMany(mappedBy = "feed")
     private List<Like> likes = new ArrayList<>();
+
+    public Feed(List<Tech> techs, String title, String content, Step step, boolean isSos, String storageUrl,
+                String deployedUrl, String thumbnailUrl) {
+        this(null, techs, title, content, step, isSos, storageUrl, deployedUrl, thumbnailUrl, 0, null,
+                Collections.emptyList());
+    }
+
+    public Feed(Long id, List<Tech> techs, String title, String content, Step step, boolean isSos, String storageUrl,
+                String deployedUrl, String thumbnailUrl, int views, User author, List<Like> likes) {
+        validateStep(step, deployedUrl);
+        this.id = id;
+        this.techs = techs;
+        this.title = title;
+        this.content = content;
+        this.step = step;
+        this.isSos = isSos;
+        this.storageUrl = storageUrl;
+        this.deployedUrl = deployedUrl;
+        this.thumbnailUrl = thumbnailUrl;
+        this.views = views;
+        this.author = author;
+        this.likes = likes;
+    }
+
+    public Feed writtenBy(User author) {
+        this.author = author;
+        author.getFeeds().add(this);
+        return this;
+    }
+
+    public void validateStep(Step step, String deployedUrl) {
+        if (step.equals(Step.COMPLETE) && Objects.isNull(deployedUrl)) {
+            throw new IllegalStateException("전시중 Step은 배포 URL이 필수입니다.");
+        }
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/FeedRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/FeedRepository.java
@@ -1,0 +1,8 @@
+package com.wooteco.nolto.feed.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+}

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Step.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Step.java
@@ -1,5 +1,20 @@
 package com.wooteco.nolto.feed.domain;
 
+import java.util.Arrays;
+
 public enum Step {
-    PROGRESS, COMPLETE
+    PROGRESS(false),
+    COMPLETE(true);
+
+    boolean hasDeployedUrl;
+
+    Step(boolean hasDeployedUrl) {
+        this.hasDeployedUrl = hasDeployedUrl;
+    }
+
+    public static Step of(String value) {
+        return Arrays.stream(values())
+                .filter(step -> step.name().equalsIgnoreCase(value))
+                .findAny().orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Step 입니다."));
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -1,0 +1,27 @@
+package com.wooteco.nolto.feed.ui;
+
+import com.wooteco.nolto.feed.application.FeedService;
+import com.wooteco.nolto.feed.ui.dto.FeedRequest;
+import com.wooteco.nolto.feed.ui.dto.FeedResponse;
+import com.wooteco.nolto.user.domain.AuthenticationPrincipal;
+import com.wooteco.nolto.user.domain.User;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@AllArgsConstructor
+@RestController("/feeds")
+public final class FeedController {
+
+    private final FeedService feedService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@AuthenticationPrincipal User user ,@RequestBody FeedRequest request) {
+        FeedResponse response = feedService.create(user, request);
+        return ResponseEntity.created(URI.create("/feeds/" + response.getId())).build();
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedRequest.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedRequest.java
@@ -1,0 +1,43 @@
+package com.wooteco.nolto.feed.ui.dto;
+
+import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.feed.domain.Step;
+import com.wooteco.nolto.tech.domain.Tech;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedRequest {
+    @NotBlank
+    private String title;
+
+    private List<Tech> tech;
+
+    @NotBlank
+    private String content;
+
+    @NotBlank
+    private String step;
+
+    @NotNull
+    private boolean sos;
+
+    private String storageUrl;
+    private String deployedUrl;
+    private String thumbnailUrl;
+
+    public Feed toEntity() {
+        return new Feed(
+                this.tech, this.title, this.content, Step.of(step), this.sos, this.storageUrl, this.deployedUrl, this.thumbnailUrl
+        );
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedResponse.java
@@ -1,0 +1,16 @@
+package com.wooteco.nolto.feed.ui.dto;
+
+import com.wooteco.nolto.feed.domain.Feed;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FeedResponse {
+
+    private final Long id;
+
+    public static FeedResponse of(Feed feed) {
+        return new FeedResponse(feed.getId());
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/AuthController.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/AuthController.java
@@ -3,19 +3,17 @@ package com.wooteco.nolto.user.ui;
 import com.wooteco.nolto.user.application.AuthService;
 import com.wooteco.nolto.user.ui.dto.TokenRequest;
 import com.wooteco.nolto.user.ui.dto.TokenResponse;
+import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@AllArgsConstructor
 @RestController
 public final class AuthController {
 
     private final AuthService authService;
-
-    public AuthController(AuthService authService) {
-        this.authService = authService;
-    }
 
     @PostMapping("/login")
     public ResponseEntity<TokenResponse> login(@RequestBody TokenRequest tokenRequest) {

--- a/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedTest.java
@@ -1,0 +1,33 @@
+package com.wooteco.nolto.feed.domain;
+
+import com.wooteco.nolto.user.domain.UserTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FeedTest {
+
+    public static Feed FEED = new Feed(new ArrayList<>(), "title", "content", Step.PROGRESS, true, "", "", "");
+
+    private Feed feed1;
+
+    @BeforeEach
+    void setUp() {
+        feed1 = new Feed(new ArrayList<>(), "title", "content", Step.PROGRESS, true,
+                "", "", "");
+    }
+
+    @DisplayName("피드에 작성자 추가할 수 있다.")
+    @Test
+    void writtenBy() {
+        // when
+        Feed feed = feed1.writtenBy(UserTest.USER);
+
+        // then
+        assertThat(feed.getAuthor()).isEqualTo(UserTest.USER);
+    }
+}

--- a/backend/src/test/java/com/wooteco/nolto/user/domain/UserTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/user/domain/UserTest.java
@@ -3,27 +3,35 @@ package com.wooteco.nolto.user.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-class UserTest {
-
+public class UserTest {
     private static String EMAIL = "email@email.com";
     private static String PASSWORD = "password";
     private static String NICKNAME = "nickname";
 
+    public static User USER = new User(null, EMAIL, PASSWORD, NICKNAME, new ArrayList<>(), new ArrayList<>());
+
     @Test
     void checkPassword() {
+        // given
         User user = new User(null, EMAIL, PASSWORD, NICKNAME, Collections.emptyList(), Collections.emptyList());
+
+        // when then
         assertDoesNotThrow(() -> user.checkPassword(PASSWORD));
     }
 
     @DisplayName("비밀번호가 일치 하지 않으면 예외가 발생한다.")
     @Test
     void invalidPassword() {
+        // given
         User user = new User(null, EMAIL, "passWORD", NICKNAME, Collections.emptyList(), Collections.emptyList());
+
+        // when then
         assertThatThrownBy(() -> user.checkPassword(PASSWORD))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("로그인에 실패하였습니다.");


### PR DESCRIPTION
## 작업 내용
* 작성한 글을 DB에 저장
* Step에 따라 필수 작성 항목을 다르게 처리함
    + Step.COMPLETE 일 시 deployedUrl 은 필수 (null이 될 수 없음)
* FeedRequest, FeedResponse 추가
* DataLoader에 Feed 더미 데이터 추가

Closes #13 

## 주의사항
* FeedResponse 에 id 만 추가해둔 상태
* url 정규표현식 검사 추가 필요
* Step과 url을 묶어놓으면 어떨까에 대한 회의 필요
    + 현재는 Feed 주생성자에서 검증을 하고 있음