### PR TITLE
feat: 피드 단일 조회 기능 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
+	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2:1.4.199'

--- a/backend/src/main/java/com/wooteco/nolto/DataLoader.java
+++ b/backend/src/main/java/com/wooteco/nolto/DataLoader.java
@@ -3,7 +3,6 @@ package com.wooteco.nolto;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.FeedRepository;
 import com.wooteco.nolto.feed.domain.Step;
-import com.wooteco.nolto.feed.ui.dto.FeedResponse;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
 import lombok.AllArgsConstructor;
@@ -25,14 +24,14 @@ public class DataLoader implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
-        User mickey = new User(null, "user1@email.com", "user1", "미키", new ArrayList<>(), Collections.emptyList());
+        User mickey = new User(null, "user1@email.com", "user1", "미키", "imageUrl", new ArrayList<>(), Collections.emptyList());
         List<User> users = Arrays.asList(
                 mickey,
-                new User(null, "user2@email.com", "user2", "아마찌", Collections.emptyList(), Collections.emptyList()),
-                new User(null, "user3@email.com", "user3", "지그", Collections.emptyList(), Collections.emptyList()),
-                new User(null, "user4@email.com", "user4", "포모", Collections.emptyList(), Collections.emptyList()),
-                new User(null, "user5@email.com", "user5", "조엘", Collections.emptyList(), Collections.emptyList()),
-                new User(null, "user6@email.com", "user6", "찰리", Collections.emptyList(), Collections.emptyList())
+                new User(null, "user2@email.com", "user2", "아마찌", "imageUrl", Collections.emptyList(), Collections.emptyList()),
+                new User(null, "user3@email.com", "user3", "지그", "imageUrl", Collections.emptyList(), Collections.emptyList()),
+                new User(null, "user4@email.com", "user4", "포모", "imageUrl", Collections.emptyList(), Collections.emptyList()),
+                new User(null, "user5@email.com", "user5", "조엘", "imageUrl", Collections.emptyList(), Collections.emptyList()),
+                new User(null, "user6@email.com", "user6", "찰리", "imageUrl", Collections.emptyList(), Collections.emptyList())
         );
         userRepository.saveAll(users);
 

--- a/backend/src/main/java/com/wooteco/nolto/NotFoundException.java
+++ b/backend/src/main/java/com/wooteco/nolto/NotFoundException.java
@@ -1,4 +1,4 @@
-package com.wooteco.nolto.user.application;
+package com.wooteco.nolto;
 
 public class NotFoundException extends RuntimeException {
     public NotFoundException(String message) {

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -1,7 +1,9 @@
 package com.wooteco.nolto.feed.application;
 
+import com.wooteco.nolto.NotFoundException;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.FeedRepository;
+import com.wooteco.nolto.feed.ui.dto.FeedDetailResponse;
 import com.wooteco.nolto.feed.ui.dto.FeedRequest;
 import com.wooteco.nolto.feed.ui.dto.FeedResponse;
 import com.wooteco.nolto.user.domain.User;
@@ -14,9 +16,18 @@ public class FeedService {
 
     private final FeedRepository feedRepository;
 
-    public FeedResponse create(User user, FeedRequest request) {
+    public FeedDetailResponse create(User user, FeedRequest request) {
         Feed feed = request.toEntity().writtenBy(user);
         Feed savedFeed = feedRepository.save(feed);
-        return FeedResponse.of(savedFeed);
+        return FeedDetailResponse.of(savedFeed);
+    }
+
+    public FeedResponse findById(User user, Long feedId) {
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new NotFoundException("피드를 찾을 수 없습니다."));
+
+        User author = feed.getAuthor();
+        boolean liked = feed.isLikedByUser(user);
+        return FeedResponse.of(author, feed, liked);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
@@ -57,7 +57,7 @@ public class Feed {
     public Feed(List<Tech> techs, String title, String content, Step step, boolean isSos, String storageUrl,
                 String deployedUrl, String thumbnailUrl) {
         this(null, techs, title, content, step, isSos, storageUrl, deployedUrl, thumbnailUrl, 0, null,
-                Collections.emptyList());
+                new ArrayList<>());
     }
 
     public Feed(Long id, List<Tech> techs, String title, String content, Step step, boolean isSos, String storageUrl,
@@ -87,5 +87,14 @@ public class Feed {
         if (step.equals(Step.COMPLETE) && Objects.isNull(deployedUrl)) {
             throw new IllegalStateException("전시중 Step은 배포 URL이 필수입니다.");
         }
+    }
+
+    public boolean isLikedByUser(User user) {
+        for (Like like : likes) {
+            if (like.getUser().getId().equals(user.getId())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Like.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Like.java
@@ -23,4 +23,9 @@ public class Like {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_likes_to_feed"), nullable = false)
     private Feed feed;
+
+    public Like(User user, Feed feed) {
+        this.user = user;
+        this.feed = feed;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Step.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Step.java
@@ -3,14 +3,8 @@ package com.wooteco.nolto.feed.domain;
 import java.util.Arrays;
 
 public enum Step {
-    PROGRESS(false),
-    COMPLETE(true);
-
-    boolean hasDeployedUrl;
-
-    Step(boolean hasDeployedUrl) {
-        this.hasDeployedUrl = hasDeployedUrl;
-    }
+    PROGRESS,
+    COMPLETE;
 
     public static Step of(String value) {
         return Arrays.stream(values())

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -15,7 +15,7 @@ import java.net.URI;
 
 @AllArgsConstructor
 @RestController("/feeds")
-public final class FeedController {
+public class FeedController {
 
     private final FeedService feedService;
 

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -1,27 +1,34 @@
 package com.wooteco.nolto.feed.ui;
 
 import com.wooteco.nolto.feed.application.FeedService;
+import com.wooteco.nolto.feed.ui.dto.FeedDetailResponse;
 import com.wooteco.nolto.feed.ui.dto.FeedRequest;
 import com.wooteco.nolto.feed.ui.dto.FeedResponse;
 import com.wooteco.nolto.user.domain.AuthenticationPrincipal;
 import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
 @AllArgsConstructor
-@RestController("/feeds")
+@RestController
+@RequestMapping("/feeds")
 public class FeedController {
 
     private final FeedService feedService;
 
     @PostMapping
-    public ResponseEntity<Void> create(@AuthenticationPrincipal User user ,@RequestBody FeedRequest request) {
-        FeedResponse response = feedService.create(user, request);
+    public ResponseEntity<Void> create(@AuthenticationPrincipal User user, @RequestBody FeedRequest request) {
+        FeedDetailResponse response = feedService.create(user, request);
         return ResponseEntity.created(URI.create("/feeds/" + response.getId())).build();
+    }
+
+    @GetMapping(value = "/{feedId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<FeedResponse> findById(@AuthenticationPrincipal User user, @PathVariable Long feedId) {
+        FeedResponse response = feedService.findById(user, feedId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedAuthorResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedAuthorResponse.java
@@ -1,0 +1,17 @@
+package com.wooteco.nolto.feed.ui.dto;
+
+import com.wooteco.nolto.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class FeedAuthorResponse {
+    private final Long id;
+    private final String nickname;
+    private final String imageUrl;
+
+    public static FeedAuthorResponse of(User author) {
+        return new FeedAuthorResponse(author.getId(), author.getNickName(), author.getImageUrl());
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedDetailResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedDetailResponse.java
@@ -1,0 +1,34 @@
+package com.wooteco.nolto.feed.ui.dto;
+
+import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.tech.ui.dto.TechResponse;
+import com.wooteco.nolto.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class FeedDetailResponse {
+
+    private final Long id;
+    private final String title;
+    private final List<TechResponse> techs;
+    private final String content;
+    private final String step;
+    private final boolean sos;
+    private final String storageUrl;
+    private final String deployedUrl;
+    private final String thumbnailUrl;
+    private final int likes;
+    private final int views;
+
+    public static FeedDetailResponse of(Feed feed) {
+        return new FeedDetailResponse(feed.getId(), feed.getTitle(), TechResponse.of(feed.getTechs()), feed.getContent(),
+                feed.getStep().name(), feed.isSos(), feed.getStorageUrl(), feed.getDeployedUrl(), feed.getThumbnailUrl(),
+                feed.getLikes().size(), feed.getViews());
+    }
+
+}

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedResponse.java
@@ -1,16 +1,19 @@
 package com.wooteco.nolto.feed.ui.dto;
 
 import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Getter
 @AllArgsConstructor
+@Getter
 public class FeedResponse {
+    private final FeedAuthorResponse author;
+    private final FeedDetailResponse feed;
+    private final boolean liked;
 
-    private final Long id;
-
-    public static FeedResponse of(Feed feed) {
-        return new FeedResponse(feed.getId());
+    public static FeedResponse of(User author, Feed feed, boolean liked) {
+        return new FeedResponse(FeedAuthorResponse.of(author), FeedDetailResponse.of(feed), liked);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedSimpleResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedSimpleResponse.java
@@ -1,0 +1,4 @@
+package com.wooteco.nolto.feed.ui.dto;
+
+public class FeedSimpleResponse {
+}

--- a/backend/src/main/java/com/wooteco/nolto/tech/ui/dto/TechResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/tech/ui/dto/TechResponse.java
@@ -1,0 +1,19 @@
+package com.wooteco.nolto.tech.ui.dto;
+
+import com.wooteco.nolto.tech.domain.Tech;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+public class TechResponse {
+    private final Long id;
+    private final String text;
+
+    public static List<TechResponse> of(List<Tech> techs) {
+        return techs.stream()
+                .map(tech -> new TechResponse(tech.getId(), tech.getName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/user/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/AuthenticationPrincipalConfig.java
@@ -1,0 +1,26 @@
+package com.wooteco.nolto.user;
+
+import com.wooteco.nolto.user.application.AuthService;
+import com.wooteco.nolto.user.ui.AuthenticationPrincipalArgumentResolver;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@AllArgsConstructor
+public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
+    private final AuthService authService;
+
+    @Override
+    public void addArgumentResolvers(List argumentResolvers) {
+        argumentResolvers.add(createAuthenticationPrincipalArgumentResolver());
+    }
+
+    @Bean
+    public AuthenticationPrincipalArgumentResolver createAuthenticationPrincipalArgumentResolver() {
+        return new AuthenticationPrincipalArgumentResolver(authService);
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/user/application/AuthService.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/application/AuthService.java
@@ -1,5 +1,6 @@
 package com.wooteco.nolto.user.application;
 
+import com.wooteco.nolto.NotFoundException;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
 import com.wooteco.nolto.user.infrastructure.JwtTokenProvider;

--- a/backend/src/main/java/com/wooteco/nolto/user/application/AuthService.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/application/AuthService.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 public class AuthService {
 
-    private UserRepository userRepository;
-    private JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public TokenResponse login(TokenRequest tokenRequest) {
         User findUser = getFindUser(tokenRequest.getEmail());

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -35,6 +35,10 @@ public class User {
     @NotBlank
     private String nickName;
 
+    @Column(nullable = false)
+    @NotBlank
+    private String imageUrl;
+
     @OneToMany(mappedBy = "author")
     private List<Feed> feeds = new ArrayList<>();
 

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -45,6 +45,13 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<Like> likes = new ArrayList<>();
 
+    public User(Long id, @Email @NotBlank String email, @NotBlank String password, @NotBlank String nickName) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.nickName = nickName;
+    }
+
     public void checkPassword(String password) {
         if (!this.password.equals(password)) {
             throw new IllegalArgumentException("로그인에 실패하였습니다.");

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/AuthController.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/AuthController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @AllArgsConstructor
 @RestController
-public final class AuthController {
+public class AuthController {
 
     private final AuthService authService;
 

--- a/backend/src/main/resources/logback-access.xml
+++ b/backend/src/main/resources/logback-access.xml
@@ -1,0 +1,8 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%n###### HTTP Request ######%n%fullRequest%n###### HTTP Response ######%n%fullResponse%n%n</pattern>
+        </encoder>
+    </appender>
+    <appender-ref ref="STDOUT" />
+</configuration>

--- a/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedTest.java
@@ -1,5 +1,6 @@
 package com.wooteco.nolto.feed.domain;
 
+import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,5 +30,29 @@ class FeedTest {
 
         // then
         assertThat(feed.getAuthor()).isEqualTo(UserTest.USER);
+    }
+
+    @DisplayName("해당 피드에 사용자가 좋아요를 눌렀는지 검증할 수 있다.")
+    @Test
+    void likedByUser() {
+        Feed feed = feed1.writtenBy(UserTest.USER);
+
+        User likedUser = new User(1L, "EMAIL", "PASSWORD", "JOEL");
+        feed.getLikes().add(new Like(likedUser, feed));
+
+        assertThat(feed.isLikedByUser(likedUser)).isTrue();
+    }
+
+
+    @DisplayName("해당 피드에 사용자가 좋아요를 누르지 않았는지 검증할 수 있다.")
+    @Test
+    void notLikedByUser() {
+        Feed feed = feed1.writtenBy(UserTest.USER);
+
+        User likedUser = new User(1L, "EMAIL", "PASSWORD", "JOEL");
+        feed.getLikes().add(new Like(likedUser, feed));
+
+        User notLikedUser = new User(2L, "EMAIL", "PASSWORD", "POMO");
+        assertThat(feed.isLikedByUser(notLikedUser)).isFalse();
     }
 }

--- a/backend/src/test/java/com/wooteco/nolto/user/domain/UserTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/user/domain/UserTest.java
@@ -14,12 +14,12 @@ public class UserTest {
     private static String PASSWORD = "password";
     private static String NICKNAME = "nickname";
 
-    public static User USER = new User(null, EMAIL, PASSWORD, NICKNAME, new ArrayList<>(), new ArrayList<>());
+    public static User USER = new User(null, EMAIL, PASSWORD, NICKNAME);
 
     @Test
     void checkPassword() {
         // given
-        User user = new User(null, EMAIL, PASSWORD, NICKNAME, Collections.emptyList(), Collections.emptyList());
+        User user = new User(null, EMAIL, PASSWORD, NICKNAME);
 
         // when then
         assertDoesNotThrow(() -> user.checkPassword(PASSWORD));
@@ -29,7 +29,7 @@ public class UserTest {
     @Test
     void invalidPassword() {
         // given
-        User user = new User(null, EMAIL, "passWORD", NICKNAME, Collections.emptyList(), Collections.emptyList());
+        User user = new User(null, EMAIL, "passWORD", NICKNAME);
 
         // when then
         assertThatThrownBy(() -> user.checkPassword(PASSWORD))


### PR DESCRIPTION
## 작업 내용
- 단일 피드 조회 기능 추가
- http 요청 로그백 추가

Closes #9 


## 주의사항
- Jackson에서 Java Object -> JSON 변환시 getter가 필수
- Feed에 좋아요를 누른 User를 찾는 로직 리팩토링 필요
