### PR TITLE
feat: 최신 피드 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -3,12 +3,13 @@ package com.wooteco.nolto.feed.application;
 import com.wooteco.nolto.NotFoundException;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.FeedRepository;
-import com.wooteco.nolto.feed.ui.dto.FeedDetailResponse;
-import com.wooteco.nolto.feed.ui.dto.FeedRequest;
-import com.wooteco.nolto.feed.ui.dto.FeedResponse;
+import com.wooteco.nolto.feed.ui.dto.*;
 import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @Service
@@ -32,5 +33,12 @@ public class FeedService {
     public Feed findEntityById(Long feedId) {
         return feedRepository.findById(feedId)
                 .orElseThrow(() -> new NotFoundException("피드를 찾을 수 없습니다."));
+    }
+
+    public List<FeedCardResponse> findAll() {
+        return feedRepository.findAll()
+                .stream()
+                .map(FeedCardResponse::of)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -3,13 +3,17 @@ package com.wooteco.nolto.feed.application;
 import com.wooteco.nolto.NotFoundException;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.FeedRepository;
-import com.wooteco.nolto.feed.ui.dto.*;
+import com.wooteco.nolto.feed.domain.Filter;
+import com.wooteco.nolto.feed.ui.dto.FeedCardResponse;
+import com.wooteco.nolto.feed.ui.dto.FeedDetailResponse;
+import com.wooteco.nolto.feed.ui.dto.FeedRequest;
+import com.wooteco.nolto.feed.ui.dto.FeedResponse;
 import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @Service
@@ -35,10 +39,9 @@ public class FeedService {
                 .orElseThrow(() -> new NotFoundException("피드를 찾을 수 없습니다."));
     }
 
-    public List<FeedCardResponse> findAll() {
-        return feedRepository.findAll()
-                .stream()
-                .map(FeedCardResponse::of)
-                .collect(Collectors.toList());
+    public List<FeedCardResponse> findAll(String filter) {
+        Filter findFilter = Filter.of(filter);
+        List<Feed> feeds = feedRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
+        return FeedCardResponse.toList(findFilter.execute(feeds));
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Filter.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Filter.java
@@ -1,0 +1,32 @@
+package com.wooteco.nolto.feed.domain;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum Filter {
+    ALL(feed -> true),
+    SOS(Feed::isSos),
+    PROGRESS(feed -> feed.getStep().equals(Step.PROGRESS)),
+    COMPLETE(feed -> feed.getStep().equals(Step.COMPLETE));
+
+    private Function<Feed, Boolean> function;
+
+    Filter(Function<Feed, Boolean> function) {
+        this.function = function;
+    }
+
+    public static Filter of(String value) {
+        return Arrays.stream(Filter.values())
+                .filter(filter -> filter.name().equalsIgnoreCase(value))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 필터링 값입니다."));
+    }
+
+    public List<Feed> execute(List<Feed> feedCards) {
+        return feedCards.stream()
+                .filter(feed -> this.function.apply(feed))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -4,9 +4,7 @@ import com.wooteco.nolto.auth.MemberAuthenticationPrincipal;
 import com.wooteco.nolto.auth.UserAuthenticationPrincipal;
 import com.wooteco.nolto.feed.application.FeedService;
 import com.wooteco.nolto.feed.application.LikeService;
-import com.wooteco.nolto.feed.ui.dto.FeedDetailResponse;
-import com.wooteco.nolto.feed.ui.dto.FeedRequest;
-import com.wooteco.nolto.feed.ui.dto.FeedResponse;
+import com.wooteco.nolto.feed.ui.dto.*;
 import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
 import org.springframework.http.MediaType;
@@ -14,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @AllArgsConstructor
 @RestController
@@ -45,5 +44,11 @@ public class FeedController {
     public ResponseEntity<Void> deleteLike(@MemberAuthenticationPrincipal User user, @PathVariable Long feedId) {
         likeService.deleteLike(user, feedId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/recent")
+    public ResponseEntity<List<FeedCardResponse>> recentResponse() {
+        List<FeedCardResponse> feeds = feedService.findAll();
+        return ResponseEntity.ok(feeds);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -4,7 +4,10 @@ import com.wooteco.nolto.auth.MemberAuthenticationPrincipal;
 import com.wooteco.nolto.auth.UserAuthenticationPrincipal;
 import com.wooteco.nolto.feed.application.FeedService;
 import com.wooteco.nolto.feed.application.LikeService;
-import com.wooteco.nolto.feed.ui.dto.*;
+import com.wooteco.nolto.feed.ui.dto.FeedCardResponse;
+import com.wooteco.nolto.feed.ui.dto.FeedDetailResponse;
+import com.wooteco.nolto.feed.ui.dto.FeedRequest;
+import com.wooteco.nolto.feed.ui.dto.FeedResponse;
 import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
 import org.springframework.http.MediaType;
@@ -47,8 +50,8 @@ public class FeedController {
     }
 
     @GetMapping("/recent")
-    public ResponseEntity<List<FeedCardResponse>> recentResponse() {
-        List<FeedCardResponse> feeds = feedService.findAll();
+    public ResponseEntity<List<FeedCardResponse>> recentResponse(@RequestParam(required = false, defaultValue = "all") String filter) {
+        List<FeedCardResponse> feeds = feedService.findAll(filter);
         return ResponseEntity.ok(feeds);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardResponse.java
@@ -4,6 +4,9 @@ import com.wooteco.nolto.feed.domain.Feed;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Getter
 @AllArgsConstructor
 public class FeedCardResponse {
@@ -12,5 +15,11 @@ public class FeedCardResponse {
 
     public static FeedCardResponse of(Feed feed) {
         return new FeedCardResponse(FeedAuthorResponse.of(feed.getAuthor()), FeedSimpleResponse.of(feed));
+    }
+
+    public static List<FeedCardResponse> toList(List<Feed> feed) {
+        return feed.stream()
+                .map(FeedCardResponse::of)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardResponse.java
@@ -1,0 +1,16 @@
+package com.wooteco.nolto.feed.ui.dto;
+
+import com.wooteco.nolto.feed.domain.Feed;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FeedCardResponse {
+    private final FeedAuthorResponse author;
+    private final FeedSimpleResponse feed;
+
+    public static FeedCardResponse of(Feed feed) {
+        return new FeedCardResponse(FeedAuthorResponse.of(feed.getAuthor()), FeedSimpleResponse.of(feed));
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedSimpleResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedSimpleResponse.java
@@ -1,4 +1,28 @@
 package com.wooteco.nolto.feed.ui.dto;
 
+import com.wooteco.nolto.feed.domain.Feed;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class FeedSimpleResponse {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final String step;
+    private final boolean sos;
+    private final String thumbnailUrl;
+
+    public static FeedSimpleResponse of(Feed feed) {
+        return new FeedSimpleResponse(
+                feed.getId(),
+                feed.getTitle(),
+                feed.getContent(),
+                feed.getStep().name(),
+                feed.isSos(),
+                feed.getThumbnailUrl()
+        );
+    }
 }


### PR DESCRIPTION
## 작업 내용

- 최신 피드를 조회한다. (default = 최신순 피드)
- 최신 피드의 필터링을 추가한다.
   - SOS인가?
   - Step이 complete인가?
   - Step이 progress인가?

Closes #10 

## 주의사항

- 현재 최신 피드는 id순으로 가고 있다.
- 추후에 생성 날짜 순으로 수정이 필요
