### PR TITLE
fix(feed): find-all 시 빈 프로퍼티를 매개변수로 받는 문제 해결

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -47,7 +47,7 @@ public class FeedService {
 
     public List<FeedCardResponse> findAll(String filter) {
         FilterStrategy strategy = FilterStrategy.of(filter);
-        Feeds feeds = new Feeds(feedRepository.findAll(Sort.by(Sort.Direction.DESC, "id", "")));
+        Feeds feeds = new Feeds(feedRepository.findAll(Sort.by(Sort.Direction.DESC, "id")));
         return FeedCardResponse.toList(feeds.filter(strategy));
     }
 }


### PR DESCRIPTION
## 작업 내용

- findAll 시 빈 프로퍼티를 매개변수로 받는 문제 해결
- Closes #52 

## 주의사항
- 코딩 조심하자
- 이상한 코드 남기고 커밋하지 말좌