### PR TITLE
feat(image): S3 저장소로 이미지 업로드 기능 구현 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 
 	// Maria DB
 	implementation("org.mariadb.jdbc:mariadb-java-client:2.1.2")
+
+	// AWS S3
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-aws-core', version: '2.2.6.RELEASE'
 }
 
 test {

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -8,6 +8,7 @@ import com.wooteco.nolto.feed.domain.FilterStrategy;
 import com.wooteco.nolto.feed.ui.dto.FeedCardResponse;
 import com.wooteco.nolto.feed.ui.dto.FeedRequest;
 import com.wooteco.nolto.feed.ui.dto.FeedResponse;
+import com.wooteco.nolto.image.application.ImageService;
 import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -19,10 +20,12 @@ import java.util.List;
 @Service
 public class FeedService {
 
+    private final ImageService imageService;
     private final FeedRepository feedRepository;
 
     public Long create(User user, FeedRequest request) {
-        Feed feed = request.toEntity().writtenBy(user);
+        String thumbnailUrl = imageService.upload(request.getThumbnailImage());
+        Feed feed = request.toEntityWithThumbnailUrl(thumbnailUrl).writtenBy(user);
         Feed savedFeed = feedRepository.save(feed);
         return savedFeed.getId();
     }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -25,7 +25,7 @@ public class FeedController {
     private final LikeService likeService;
 
     @PostMapping
-    public ResponseEntity<Void> create(@MemberAuthenticationPrincipal User user, @RequestBody FeedRequest request) {
+    public ResponseEntity<Void> create(@MemberAuthenticationPrincipal User user, @ModelAttribute FeedRequest request) {
         Long feedId = feedService.create(user, request);
         return ResponseEntity.created(URI.create("/feeds/" + feedId)).build();
     }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedRequest.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedRequest.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -33,11 +34,9 @@ public class FeedRequest {
 
     private String storageUrl;
     private String deployedUrl;
-    private String thumbnailUrl;
+    private MultipartFile thumbnailImage;
 
-    public Feed toEntity() {
-        return new Feed(
-                this.tech, this.title, this.content, Step.of(step), this.sos, this.storageUrl, this.deployedUrl, this.thumbnailUrl
-        );
+    public Feed toEntityWithThumbnailUrl(String thumbnailUrl) {
+        return new Feed(this.tech, this.title, this.content, Step.of(step), this.sos, this.storageUrl, this.deployedUrl, thumbnailUrl);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/image/application/ImageService.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/application/ImageService.java
@@ -1,0 +1,42 @@
+package com.wooteco.nolto.image.application;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+@Service
+public class ImageService {
+    @Value("${application.bucket.name}")
+    private String bucketName;
+
+    private AmazonS3 amazonS3Client;
+
+    public ImageService(AmazonS3 amazonS3Client) {
+        this.amazonS3Client = amazonS3Client;
+    }
+
+    public String upload(MultipartFile multipartFile) {
+        File file = convertToFile(multipartFile);
+        String fileName = System.currentTimeMillis() + Base64.encodeAsString(multipartFile.getName().getBytes()) + multipartFile.getContentType();
+        amazonS3Client.putObject(new PutObjectRequest(bucketName, fileName, file));
+        file.delete();
+        return fileName;
+    }
+
+    private File convertToFile(MultipartFile multipartFile) {
+        File convertedFile = new File(multipartFile.getOriginalFilename());
+        try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
+            fos.write(multipartFile.getBytes());
+        } catch (IOException e) {
+            throw new IllegalStateException("파일 변환 실패!");
+        }
+        return convertedFile;
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/image/application/ImageService.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/application/ImageService.java
@@ -16,7 +16,10 @@ public class ImageService {
     @Value("${application.bucket.name}")
     private String bucketName;
 
-    private AmazonS3 amazonS3Client;
+    @Value("${application.cloudfront.url}")
+    private String cloudfrontUrl;
+
+    private final AmazonS3 amazonS3Client;
 
     public ImageService(AmazonS3 amazonS3Client) {
         this.amazonS3Client = amazonS3Client;
@@ -27,7 +30,7 @@ public class ImageService {
         String fileName = System.currentTimeMillis() + Base64.encodeAsString(multipartFile.getName().getBytes()) + multipartFile.getContentType();
         amazonS3Client.putObject(new PutObjectRequest(bucketName, fileName, file));
         file.delete();
-        return fileName;
+        return cloudfrontUrl + "/" + fileName;
     }
 
     private File convertToFile(MultipartFile multipartFile) {
@@ -40,3 +43,4 @@ public class ImageService {
         return convertedFile;
     }
 }
+

--- a/backend/src/main/java/com/wooteco/nolto/image/config/ImageConfig.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/config/ImageConfig.java
@@ -1,0 +1,21 @@
+package com.wooteco.nolto.image.config;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ImageConfig {
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 generateS3Client() {
+        return AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .build();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -48,6 +48,12 @@ security:
       secret-key: my_secret_is_secret
       expire-length: 3600000
 spring:
+  servlet:
+    multipart:
+      enabled: true
+      file-size-threshold: 2MB
+      max-file-size: 5MB
+      max-request-size: 10MB
   jpa:
     properties:
       hibernate:
@@ -65,4 +71,15 @@ logging:
           descriptor:
             sql:
               BasicBinder: TRACE
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+application:
+  bucket:
+    name: 2021-nolto
+  cloudfront:
+    url: dksykemwl00pf.cloudfront.net
 


### PR DESCRIPTION
## 작업 내용
- s3 저장소 연동
- feed 업로드시 이미지 파일 받아서 저장하는 기능 구현

Closes #93 

## 주의사항
- s3 라이브러리 사용 관련 테스트 구현 고려해보기 
- 프론트한테 기능을 주기 위해 빠르게 배포해보는 단계이므로 검증이 필요함