### PR TITLE
feat:  글쓰기에 생성/수정 날짜 및 시간 추가

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/BaseEntity.java
+++ b/backend/src/main/java/com/wooteco/nolto/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.wooteco.nolto;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+}

--- a/backend/src/main/java/com/wooteco/nolto/NoltoApplication.java
+++ b/backend/src/main/java/com/wooteco/nolto/NoltoApplication.java
@@ -2,7 +2,9 @@ package com.wooteco.nolto;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class NoltoApplication {
 

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -48,13 +48,13 @@ public class FeedService {
     }
 
     public List<FeedCardResponse> findHotFeeds() {
-        Feeds feeds = new Feeds(feedRepository.findAll(Sort.by(Sort.Direction.DESC, "id")));
+        Feeds feeds = new Feeds(feedRepository.findAll(Sort.by(Sort.Direction.DESC, "createdDate")));
         return FeedCardResponse.toList(feeds.sortedByLikeCount(10));
     }
 
     public List<FeedCardResponse> findAll(String filter) {
         FilterStrategy strategy = FilterStrategy.of(filter);
-        Feeds feeds = new Feeds(feedRepository.findAll(Sort.by(Sort.Direction.DESC, "id")));
+        Feeds feeds = new Feeds(feedRepository.findAll(Sort.by(Sort.Direction.DESC, "createdDate")));
         return FeedCardResponse.toList(feeds.filter(strategy));
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
@@ -1,5 +1,6 @@
 package com.wooteco.nolto.feed.domain;
 
+import com.wooteco.nolto.BaseEntity;
 import com.wooteco.nolto.tech.domain.Tech;
 import com.wooteco.nolto.user.domain.User;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import java.util.stream.Collectors;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Feed {
+public class Feed extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/test/java/com/wooteco/nolto/BaseEntityTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/BaseEntityTest.java
@@ -1,0 +1,92 @@
+package com.wooteco.nolto;
+
+import com.wooteco.nolto.feed.application.LikeService;
+import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.feed.domain.Step;
+import com.wooteco.nolto.feed.domain.repository.FeedRepository;
+import com.wooteco.nolto.user.domain.User;
+import com.wooteco.nolto.user.domain.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import javax.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+class BaseEntityTest {
+
+    @Autowired
+    private EntityManager entityManager;
+    @Autowired
+    private FeedRepository feedRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user1;
+    private User user2;
+
+    private Feed feed1;
+    private Feed feed2;
+    private Feed feed3;
+
+    @BeforeEach
+    void setUp() {
+        user1 = new User("user1@email.com", "user1", "아마찌", "imageUrl");
+        user2 = new User("user2@email.com", "user2", "지그", "imageUrl");
+
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        feed1 = new Feed("title1", "content1", Step.PROGRESS, true,
+                "storageUrl", "", "http://thumbnailUrl.ppnngg");
+        feed2 = new Feed("title2", "content2", Step.PROGRESS, false,
+                "", "deployUrl", "http://thumbnailUrl.pnggg");
+        feed3 = new Feed("title3", "content3", Step.COMPLETE, false,
+                "storageUrl", "deployUrl", "http://thumbnailUrl.ddd");
+
+        feed1.writtenBy(user1);
+        feed2.writtenBy(user2);
+        feed3.writtenBy(user2);
+    }
+
+    @DisplayName("피드 저장 시 생성 날짜가 저장된다.")
+    @Test
+    void save() {
+        // when
+        Feed savedFeed1 = feedRepository.save(feed1);
+        Feed savedFeed2 = feedRepository.save(feed2);
+        Feed savedFeed3 = feedRepository.save(feed3);
+        entityManager.flush();
+
+        // then
+        assertThat(savedFeed1.getCreatedDate()).isNotNull();
+        assertThat(savedFeed1.getModifiedDate()).isNotNull();
+    }
+
+    @DisplayName("데이터 변경 시 lastModifiedDate가 수정된다")
+    @Test
+    void update() {
+        // given
+        Feed savedFeed2 = feedRepository.save(feed2);
+        LocalDateTime modifiedDate = savedFeed2.getModifiedDate(); // 생성 시점
+
+        // when
+        savedFeed2.writtenBy(user1);
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        Feed findFeed = feedRepository.findById(savedFeed2.getId()).get();
+        LocalDateTime changedUpdatedAt = findFeed.getModifiedDate();
+        assertThat(modifiedDate).isNotEqualTo(changedUpdatedAt);
+    }
+
+}

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
@@ -195,7 +195,32 @@ class FeedServiceTest {
         피드_정보가_같은지_조회(FEED_REQUEST1, hotFeeds.get(2));
     }
 
-    @DisplayName("모든 피드를 조회한다. (최신 등록된 id 순)")
+    @DisplayName("좋아요 개수가 같은 경우 최신 Feed를 가져온다.(피드1: 좋아요0개, 피드2: 좋아요2개, 피드3: 좋아요2개)")
+    @Test
+    void findHotFeedsBySameDate() {
+        // given
+        Long firstFeedId = feedService.create(user1, FEED_REQUEST1);
+        Long secondFeedId = feedService.create(user1, FEED_REQUEST2);
+        Long thirdFeedId = feedService.create(user1, FEED_REQUEST3);
+
+        likeService.addLike(user2, secondFeedId);
+        likeService.addLike(user2, thirdFeedId);
+        likeService.addLike(user1, secondFeedId);
+        likeService.addLike(user1, thirdFeedId);
+        em.flush();
+        em.clear();
+
+        // when
+        List<FeedCardResponse> hotFeeds = feedService.findHotFeeds();
+
+        // then
+        assertThat(hotFeeds).hasSize(3);
+        피드_정보가_같은지_조회(FEED_REQUEST3, hotFeeds.get(0));
+        피드_정보가_같은지_조회(FEED_REQUEST2, hotFeeds.get(1));
+        피드_정보가_같은지_조회(FEED_REQUEST1, hotFeeds.get(2));
+    }
+
+    @DisplayName("모든 피드를 조회한다. (최신 등록된 날짜 순)")
     @Test
     void findAllWithAllFilter() {
         // given
@@ -214,7 +239,7 @@ class FeedServiceTest {
         피드_정보가_같은지_조회(FEED_REQUEST3, allFeeds.get(0));
     }
 
-    @DisplayName("SOS 피드를 조회한다. (최신 등록된 id 순)")
+    @DisplayName("SOS 피드를 조회한다. (최신 등록된 날짜 순)")
     @Test
     void findAllWithFilterSOS() {
         // given
@@ -236,7 +261,7 @@ class FeedServiceTest {
         피드_정보가_같은지_조회(FEED_REQUEST3, allFeeds.get(0));
     }
 
-    @DisplayName("PROGRESS 피드를 조회한다. (최신 등록된 id 순)")
+    @DisplayName("PROGRESS 피드를 조회한다. (최신 등록된 날짜 순)")
     @Test
     void findAllWithFilterProgress() {
         // given
@@ -257,7 +282,7 @@ class FeedServiceTest {
         피드_정보가_같은지_조회(FEED_REQUEST2, allFeeds.get(1));
     }
 
-    @DisplayName("COMPLETE 피드를 조회한다. (최신 등록된 id 순)")
+    @DisplayName("COMPLETE 피드를 조회한다. (최신 등록된 날짜 순)")
     @Test
     void findAllWithFilterComplete() {
         // given

--- a/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedRepositoryTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedRepositoryTest.java
@@ -50,11 +50,10 @@ class FeedRepositoryTest {
         feed2.writtenBy(user2);
         feed3.writtenBy(user2);
 
-        // then
+        // when
         Feed savedFeed1 = feedRepository.save(feed1);
         Feed savedFeed2 = feedRepository.save(feed2);
         Feed savedFeed3 = feedRepository.save(feed3);
-
 
         // then
         assertThat(savedFeed1.getId()).isNotNull();


### PR DESCRIPTION
## 작업 내용

- 생성/수정 날짜 추가 및 테스트 코드 작성
- 피드 조회 시 생성, 수정 날짜 순으로 정렬 및 테스트 코드 추가
- Close #25 

## 주의사항

- 생성 날짜를 테스트 하는 부분에서 기존의 id 순으로 테스트 하던 것과 결국 똑같음 ㅠㅠ 
- 확실한 통합 테스트를 위해서는 setId()나 setCreatedDate()가 필요한데 다 private으로 막혀있어오,,,
- 근데 CreatedDate()나 UpdatedDate()가 정상적으로 들어가는 테스트는 구현 되어 있어서 일단 풀리퀘 날립니다 👍