### PR TITLE
fix(): 단일 조회에서 수정 날짜 제거

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedResponse.java
@@ -26,11 +26,10 @@ public class FeedResponse {
     private final int views;
     private final boolean liked;
     private final LocalDateTime createdDate;
-    private final LocalDateTime modifiedDate;
 
     public static FeedResponse of(User author, Feed feed, boolean liked) {
         return new FeedResponse(FeedAuthorResponse.of(author), feed.getId(), feed.getTitle(), TechResponse.toList(feed.getTechs()),
                 feed.getContent(), feed.getStep().name(), feed.isSos(), feed.getStorageUrl(), feed.getDeployedUrl(),
-                feed.getThumbnailUrl(), feed.getLikes().size(), feed.getViews(), liked, feed.getCreatedDate(), feed.getModifiedDate());
+                feed.getThumbnailUrl(), feed.getLikes().size(), feed.getViews(), liked, feed.getCreatedDate());
     }
 }

--- a/backend/src/test/java/com/wooteco/nolto/api/FeedControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/FeedControllerTest.java
@@ -58,7 +58,7 @@ public class FeedControllerTest extends ControllerTest {
 
     private static final FeedResponse FEED_RESPONSE = new FeedResponse(FeedAuthorResponse.of(LOGIN_USER), FEED1.getId(), FEED1.getTitle(), TechControllerTest.TECH_RESPONSES,
             FEED1.getContent(), FEED1.getStep().name(), FEED1.isSos(), FEED1.getStorageUrl(), FEED1.getDeployedUrl(),
-            FEED1.getThumbnailUrl(), FEED1.getLikes().size(), FEED1.getViews(), true, LocalDateTime.now(), LocalDateTime.now());
+            FEED1.getThumbnailUrl(), FEED1.getLikes().size(), FEED1.getViews(), true, LocalDateTime.now());
 
     private static final FieldDescriptor[] TECH = new FieldDescriptor[]{
             fieldWithPath("id").type(JsonFieldType.NUMBER).description("기술 ID"),
@@ -156,7 +156,6 @@ public class FeedControllerTest extends ControllerTest {
                                 fieldWithPath("thumbnailUrl").type(JsonFieldType.STRING).description("썸네일 URL"),
                                 fieldWithPath("likes").type(JsonFieldType.NUMBER).description("좋아요 개수"),
                                 fieldWithPath("createdDate").type(JsonFieldType.STRING).description("작성 날짜"),
-                                fieldWithPath("modifiedDate").type(JsonFieldType.STRING).description("수정 날짜"),
                                 fieldWithPath("views").type(JsonFieldType.NUMBER).description("조회수"),
                                 fieldWithPath("liked").type(JsonFieldType.BOOLEAN).description("현재 로그인한 유저의 현재 글 좋아요 여부")
                         ).andWithPrefix("techs.[].", TECH)


### PR DESCRIPTION
## 작업 내용
- 글이 수정되지 않으면 수정 날짜가 존재하지 않는데 이를 필수값으로 주기에 에러 발생
- 피드 상세 조회시 수정 날짜 제거

## 주의사항
- 글쎼유