### PR TITLE
[FE] feat: Home의 Hot Toys 보여줄 개수 설정, carousel 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",
     "babel-loader": "^8.2.2",
+    "babel-plugin-styled-components": "^1.13.2",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",

--- a/frontend/src/assets/carouselArrow.svg
+++ b/frontend/src/assets/carouselArrow.svg
@@ -1,16 +1,3 @@
-<svg width="current" height="current" viewBox="0 0 32 43" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g filter="url(#filter0_d)">
-<path d="M4.99598 19.0714C3.97889 18.2707 3.97889 16.7293 4.99598 15.9286L24.5128 0.563046C25.8248 -0.469856 27.75 0.464703 27.75 2.13447L27.75 32.8655C27.75 34.5353 25.8248 35.4699 24.5128 34.437L4.99598 19.0714Z" fill="#FFAE54"/>
-</g>
-<defs>
-<filter id="filter0_d" x="0.233154" y="0.130737" width="31.5168" height="42.7385" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
-<feOffset dy="4"/>
-<feGaussianBlur stdDeviation="2"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
-</filter>
-</defs>
+<svg width="current" height="current" viewBox="0 0 14 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1L12 10.1935L1 20" stroke="#FDA085" stroke-width="2"/>
 </svg>

--- a/frontend/src/components/LevelLinkButton/LevelLinkButton.styles.ts
+++ b/frontend/src/components/LevelLinkButton/LevelLinkButton.styles.ts
@@ -14,10 +14,10 @@ const Button = styled.div<{ selected: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 7.75rem;
-  height: 7.75rem;
+  width: 6rem;
+  height: 6rem;
   border-radius: 50%;
-  font-size: 64px;
+  font-size: 3rem;
   box-shadow: ${({ selected }) => selected && 'inset'} 4px 4px 8px rgba(85, 85, 85, 0.25);
   cursor: pointer;
 `;
@@ -35,9 +35,8 @@ const SOS = styled(Button)`
 `;
 
 const Text = styled.span`
-  font-size: 18px;
   color: ${PALETTE.PRIMARY_400};
-  margin-top: 20px;
+  margin-top: 1rem;
 `;
 
 export default { Root, Progress, Complete, SOS, Text };

--- a/frontend/src/components/RegularCard/RegularCard.styles.ts
+++ b/frontend/src/components/RegularCard/RegularCard.styles.ts
@@ -31,10 +31,11 @@ const ContentArea = styled.div`
   width: 100%;
   height: 6.75rem;
   padding: 0.75rem 1rem;
+  text-align: left;
+  color: ${PALETTE.WHITE_400};
   background: rgba(51, 51, 51, 0.25);
   backdrop-filter: blur(2px);
   border-radius: 0px 0px 20px 20px;
-  color: ${PALETTE.WHITE_400};
 `;
 
 const Title = styled.h3`

--- a/frontend/src/hooks/@common/useOnScreen.ts
+++ b/frontend/src/hooks/@common/useOnScreen.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+const useOnScreen = (ref: React.RefObject<HTMLElement>) => {
+  const [isIntersecting, setIntersecting] = useState(false);
+
+  const observer = new IntersectionObserver(([entry]) => setIntersecting(entry.isIntersecting));
+
+  useEffect(() => {
+    observer.observe(ref.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return isIntersecting;
+};
+
+export default useOnScreen;

--- a/frontend/src/pages/Home/Home.styles.ts
+++ b/frontend/src/pages/Home/Home.styles.ts
@@ -136,8 +136,8 @@ const VerticalAvatar = styled(Avatar)`
 const LevelButtonsContainer = styled.div`
   display: flex;
   justify-content: center;
-  gap: 48px;
-  margin-bottom: 60px;
+  gap: 2rem;
+  margin-bottom: 3.5rem;
 `;
 
 const MoreButton = styled.button`

--- a/frontend/src/pages/Home/Home.styles.ts
+++ b/frontend/src/pages/Home/Home.styles.ts
@@ -5,6 +5,7 @@ import Searchbar from 'components/Searchbar/Searchbar';
 import HighLightedText from 'components/@common/HighlightedText/HighlightedText';
 import TextButton from 'components/@common/TextButton/TextButton';
 import Avatar from 'components/@common/Avatar/Avatar';
+import IconButtonComponent from 'components/@common/IconButton/IconButton';
 import CarouselArrow from 'assets/carouselArrow.svg';
 
 const Root = styled.div`
@@ -74,20 +75,46 @@ const HotToysContainer = styled.div`
   margin-bottom: 128px;
 `;
 
-const HotToyCardsContainer = styled.ul`
+const HotToyCardsContainer = styled.ul<{ position: number }>`
+  grid-row: 1 / 2;
+  grid-column: 1 / 8;
+  width: 100%;
+  height: 25rem;
+  padding: 0 1rem;
+
   display: flex;
-  gap: 5rem;
+  align-items: center;
   justify-content: center;
+  overflow: hidden;
+  transform-style: preserve-3d;
+  perspective: 600px;
+  --items: 5;
+  --middle: 3;
+  --position: ${({ position }) => position};
+`;
+
+const HotToyCardWrapper = styled.li<{ offset: number }>`
+  position: absolute;
+  --r: calc(var(--position) - var(--offset));
+  --abs: max(calc(var(--r) * -1), var(--r));
+  transition: all 0.25s linear;
+  transform: rotateY(calc(-10deg * var(--r))) translateX(calc(-300px * var(--r)));
+  z-index: calc((var(--position) - var(--abs)));
+  --offset: ${({ offset }) => offset};
+  cursor: pointer;
+`;
+
+export const CarouselArrowButton = styled(IconButtonComponent)`
+  width: 1.85rem;
+  height: 1.85rem;
+  padding: 0.55rem;
 `;
 
 const CarouselLeft = styled(CarouselArrow)`
-  cursor: pointer;
+  transform: rotate(180deg);
 `;
 
-const CarouselRight = styled(CarouselArrow)`
-  transform: rotate(180deg);
-  cursor: pointer;
-`;
+const CarouselRight = styled(CarouselArrow)``;
 
 const RecentToysContainer = styled.div`
   display: flex;
@@ -134,6 +161,7 @@ export default {
   MainSearchBar,
   HotToysContainer,
   HotToyCardsContainer,
+  HotToyCardWrapper,
   CarouselLeft,
   CarouselRight,
   RecentToysContainer,

--- a/frontend/src/pages/Home/Home.styles.ts
+++ b/frontend/src/pages/Home/Home.styles.ts
@@ -30,7 +30,7 @@ const SearchContainer = styled.div`
 `;
 
 const SearchTitle = styled.div`
-  font-size: 2rem;
+  font-size: 1.75rem;
   font-weight: 500;
   color: ${PALETTE.WHITE_400};
   margin-bottom: 18px;
@@ -97,7 +97,7 @@ const HotToyCardWrapper = styled.li<{ offset: number }>`
   position: absolute;
   --r: calc(var(--position) - var(--offset));
   --abs: max(calc(var(--r) * -1), var(--r));
-  transition: all 0.25s linear;
+  transition: all 0.5s ease;
   transform: rotateY(calc(-10deg * var(--r))) translateX(calc(-300px * var(--r)));
   z-index: calc((var(--position) - var(--abs)));
   --offset: ${({ offset }) => offset};
@@ -144,7 +144,7 @@ const MoreButton = styled.button`
   display: inline;
   border: none;
   background: transparent;
-  font-size: 1.125rem;
+  font-size: 1rem;
   margin-top: 36px;
   margin-left: auto;
 `;

--- a/frontend/src/pages/Home/Home.styles.ts
+++ b/frontend/src/pages/Home/Home.styles.ts
@@ -6,7 +6,7 @@ import HighLightedText from 'components/@common/HighlightedText/HighlightedText'
 import TextButton from 'components/@common/TextButton/TextButton';
 import Avatar from 'components/@common/Avatar/Avatar';
 import IconButtonComponent from 'components/@common/IconButton/IconButton';
-import CarouselArrow from 'assets/carouselArrow.svg';
+import ArrowIcon from 'assets/carouselArrow.svg';
 
 const Root = styled.div`
   position: relative;
@@ -110,11 +110,11 @@ export const CarouselArrowButton = styled(IconButtonComponent)`
   padding: 0.55rem;
 `;
 
-const CarouselLeft = styled(CarouselArrow)`
+const CarouselLeft = styled(ArrowIcon)`
   transform: rotate(180deg);
 `;
 
-const CarouselRight = styled(CarouselArrow)``;
+const CarouselRight = styled(ArrowIcon)``;
 
 const RecentToysContainer = styled.div`
   display: flex;
@@ -149,6 +149,19 @@ const MoreButton = styled.button`
   margin-left: auto;
 `;
 
+const ArrowUp = styled(ArrowIcon)`
+  transform: rotate(-90deg);
+`;
+
+export const ScrollUpButton = styled(IconButtonComponent)`
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0.55rem;
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+`;
+
 export default {
   Root,
   SearchContainer,
@@ -169,4 +182,5 @@ export default {
   VerticalAvatar,
   LevelButtonsContainer,
   MoreButton,
+  ArrowUp,
 };

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import CroppedEllipse from 'components/CroppedEllipse/CroppedEllipse';
@@ -9,7 +9,7 @@ import Header from 'components/Header/Header';
 import useHotFeeds from 'hooks/queries/useHotFeeds';
 import useRecentFeeds from 'hooks/queries/useRecentFeeds';
 import ROUTE from 'constants/routes';
-import Styled from './Home.styles';
+import Styled, { CarouselArrowButton } from './Home.styles';
 import MoreArrow from 'assets/moreArrow.svg';
 import { ButtonStyle } from 'types';
 
@@ -18,6 +18,15 @@ const tags = ['JavaScript', 'Java', 'React.js', 'Spring'];
 const Home = () => {
   const { data: hotFeeds } = useHotFeeds();
   const { data: recentFeeds } = useRecentFeeds();
+  const [hotToyCardIdx, setHotToyCardIdx] = useState(3);
+
+  const showPreviousCards = () => {
+    if (hotToyCardIdx > 1) setHotToyCardIdx(hotToyCardIdx - 1);
+  };
+
+  const showFollowingCards = () => {
+    if (hotToyCardIdx < hotFeeds?.length) setHotToyCardIdx(hotToyCardIdx + 1);
+  };
 
   return (
     <>
@@ -41,19 +50,23 @@ const Home = () => {
         <Styled.ContentArea>
           <Styled.SectionTitle fontSize="1.75rem">Hot Toys</Styled.SectionTitle>
           <Styled.HotToysContainer>
-            <Styled.CarouselLeft width="24" />
-            <Styled.HotToyCardsContainer>
+            <CarouselArrowButton onClick={showPreviousCards}>
+              <Styled.CarouselLeft width="32px" />
+            </CarouselArrowButton>
+            <Styled.HotToyCardsContainer position={hotToyCardIdx}>
               {hotFeeds &&
-                hotFeeds.map((feed) => (
-                  <li key={feed.id}>
+                hotFeeds.map((feed, idx) => (
+                  <Styled.HotToyCardWrapper key={feed.id} offset={idx + 1}>
                     <Link to={`${ROUTE.FEEDS}/${feed.id}`}>
                       <Styled.VerticalAvatar user={feed.author} />
                       <RegularCard feed={feed} />
                     </Link>
-                  </li>
+                  </Styled.HotToyCardWrapper>
                 ))}
             </Styled.HotToyCardsContainer>
-            <Styled.CarouselRight width="24" />
+            <CarouselArrowButton onClick={showFollowingCards}>
+              <Styled.CarouselRight width="32px" />
+            </CarouselArrowButton>
           </Styled.HotToysContainer>
 
           <Styled.SectionTitle fontSize="1.75rem">Recent Toys</Styled.SectionTitle>

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
 import CroppedEllipse from 'components/CroppedEllipse/CroppedEllipse';
@@ -7,6 +7,7 @@ import StretchCard from 'components/StretchCard/StretchCard';
 import LevelLinkButton from 'components/LevelLinkButton/LevelLinkButton';
 import Header from 'components/Header/Header';
 import useHotFeeds from 'hooks/queries/useHotFeeds';
+import useOnScreen from 'hooks/@common/useOnScreen';
 import useRecentFeeds from 'hooks/queries/useRecentFeeds';
 import ROUTE from 'constants/routes';
 import Styled, { CarouselArrowButton } from './Home.styles';
@@ -18,7 +19,20 @@ const tags = ['JavaScript', 'Java', 'React.js', 'Spring'];
 const Home = () => {
   const { data: hotFeeds } = useHotFeeds();
   const { data: recentFeeds } = useRecentFeeds();
+
+  const [isHeaderFolded, setHeaderFolded] = useState(true);
   const [hotToyCardIdx, setHotToyCardIdx] = useState(3);
+
+  const ellipseRef = useRef();
+  const isEllipseVisible = useOnScreen(ellipseRef);
+
+  useEffect(() => {
+    if (isEllipseVisible) {
+      setHeaderFolded(true);
+    } else {
+      setHeaderFolded(false);
+    }
+  }, [isEllipseVisible]);
 
   const showPreviousCards = () => {
     if (hotToyCardIdx > 1) setHotToyCardIdx(hotToyCardIdx - 1);
@@ -30,9 +44,9 @@ const Home = () => {
 
   return (
     <>
-      <Header isFolded={true} />
+      <Header isFolded={isHeaderFolded} />
       <Styled.Root>
-        <Styled.EllipseWrapper>
+        <Styled.EllipseWrapper ref={ellipseRef}>
           <CroppedEllipse />
         </Styled.EllipseWrapper>
         <Styled.SearchContainer>
@@ -78,7 +92,7 @@ const Home = () => {
             </Styled.LevelButtonsContainer>
             <Styled.RecentToyCardsContainer>
               {recentFeeds &&
-                recentFeeds.map((feed) => (
+                recentFeeds.slice(0, 4).map((feed) => (
                   <li key={feed.id}>
                     <Link to={`${ROUTE.FEEDS}/${feed.id}`}>
                       <Styled.VerticalAvatar user={feed.author} />

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -10,7 +10,7 @@ import useHotFeeds from 'hooks/queries/useHotFeeds';
 import useOnScreen from 'hooks/@common/useOnScreen';
 import useRecentFeeds from 'hooks/queries/useRecentFeeds';
 import ROUTE from 'constants/routes';
-import Styled, { CarouselArrowButton } from './Home.styles';
+import Styled, { CarouselArrowButton, ScrollUpButton } from './Home.styles';
 import MoreArrow from 'assets/moreArrow.svg';
 import { ButtonStyle } from 'types';
 
@@ -33,6 +33,10 @@ const Home = () => {
       setHeaderFolded(false);
     }
   }, [isEllipseVisible]);
+
+  const scrollTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
 
   const showPreviousCards = () => {
     if (hotToyCardIdx > 1) setHotToyCardIdx(hotToyCardIdx - 1);
@@ -103,10 +107,13 @@ const Home = () => {
             </Styled.RecentToyCardsContainer>
             <Styled.MoreButton>
               MORE&nbsp;
-              <MoreArrow width="10" />
+              <MoreArrow width="10px" />
             </Styled.MoreButton>
           </Styled.RecentToysContainer>
         </Styled.ContentArea>
+        <ScrollUpButton onClick={scrollTop}>
+          <Styled.ArrowUp width="10px" />
+        </ScrollUpButton>
       </Styled.Root>
     </>
   );

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
             loader: 'babel-loader',
             options: {
               presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
-              plugins: ['@babel/plugin-transform-runtime'],
+              plugins: ['@babel/plugin-transform-runtime', 'babel-plugin-styled-components'],
             },
           },
         ],

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3462,6 +3462,16 @@ babel-plugin-react-docgen@^4.2.1:
     babel-plugin-syntax-jsx "^6.18.0"
     lodash "^4.17.11"
 
+babel-plugin-styled-components@^1.13.2:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.13.2.tgz#ebe0e6deff51d7f93fceda1819e9b96aeb88278d"
+  integrity sha512-Vb1R3d4g+MUfPQPVDMCGjm3cDocJEUTR7Xq7QS95JWWeksN1wdFRYpD2kulDgI3Huuaf1CZd+NK4KQmqUFh5dA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"


### PR DESCRIPTION
## 작업 내용

- babel-plugin-styled-components 설치
  - 브라우저 개발자도구에서 컴포넌트 이름 확인용
![image](https://user-images.githubusercontent.com/44080404/126023340-c2afded4-c641-4761-abce-9d431bed10cf.png)

- fix: `RegularCard` 글씨 정렬 왼쪽으로 배치 
Closes #138

## 스크린샷
![carousel](https://media.giphy.com/media/uRCOdThsD254W9em0a/giphy.gif)

## 주의사항
- carousel 코드 이해 못함 (출처: <https://codepen.io/onion2k/pen/xxZYBVj>)
- `RegularCard` 컨텐츠 글씨 정렬 서버에서는 잘 되나 스토리북에서는 또 약간 틀어짐
