### PR TITLE
[FE] refactor: StretchCard의 크기 작게 조정

### DIFF
--- a/frontend/src/commonStyles.ts
+++ b/frontend/src/commonStyles.ts
@@ -12,7 +12,7 @@ export interface FlexContainerProps {
 
 export const Card = styled.div`
   box-shadow: 4px 4px 8px 4px rgba(85, 85, 85, 0.2);
-  border-radius: 20px;
+  border-radius: 0.75rem;
 `;
 
 export const FlexContainer = styled.div<FlexContainerProps>`

--- a/frontend/src/components/@common/Avatar/Avatar.styles.ts
+++ b/frontend/src/components/@common/Avatar/Avatar.styles.ts
@@ -3,18 +3,18 @@ import styled from 'styled-components';
 const Root = styled.div`
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 0.75rem;
   width: 100%;
 `;
 
 const Image = styled.img`
-  width: 2rem;
-  height: 2rem;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 50%;
 `;
 
 const Nickname = styled.span`
-  font-size: 1.25rem;
+  font-size: 1rem;
 `;
 
 export default { Root, Image, Nickname };

--- a/frontend/src/components/StretchCard/StretchCard.styles.ts
+++ b/frontend/src/components/StretchCard/StretchCard.styles.ts
@@ -5,10 +5,11 @@ import { PALETTE } from 'constants/palette';
 
 const Root = styled(Card)`
   position: relative;
-  width: 42.375rem;
-  height: 7.625rem;
-  padding: 1.5rem;
+  width: 34rem;
+  height: 6rem;
+  padding: 0.75rem 1rem;
   display: flex;
+  align-items: center;
   gap: 1rem;
   cursor: pointer;
   overflow: hidden;
@@ -27,30 +28,26 @@ const Root = styled(Card)`
 `;
 
 const Thumbnail = styled.img`
-  width: 5rem;
-  height: 5rem;
-  border-radius: 16px;
+  width: 4.25rem;
+  height: 4.25rem;
+  border-radius: 0.5rem;
 `;
 
 const ChipWrapper = styled.div`
   position: absolute;
-  top: 16px;
-  right: 16px;
-`;
-
-const ContentArea = styled.div`
-  margin: 0.5rem 0;
+  top: 0.75rem;
+  right: 0.75rem;
 `;
 
 const TitleWrapper = styled.div`
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 1rem;
   margin-bottom: 1rem;
 `;
 
 const Title = styled.h3`
-  font-size: 1.25rem;
+  font-size: 1rem;
   color: inherit;
 `;
 
@@ -59,4 +56,4 @@ const Content = styled.p`
   color: inherit;
 `;
 
-export default { Root, Thumbnail, ChipWrapper, ContentArea, TitleWrapper, Title, Content };
+export default { Root, Thumbnail, ChipWrapper, TitleWrapper, Title, Content };

--- a/frontend/src/components/StretchCard/StretchCard.tsx
+++ b/frontend/src/components/StretchCard/StretchCard.tsx
@@ -17,13 +17,13 @@ const StretchCard = ({ feed }: Props) => {
       <Styled.ChipWrapper>
         <Chip.Solid>{STEP_CONVERTER[feed.step]}</Chip.Solid>
       </Styled.ChipWrapper>
-      <Styled.ContentArea>
+      <div>
         <Styled.TitleWrapper>
           <Styled.Title>{feed.title}</Styled.Title>
-          {feed.sos && <SOSFlag width="56" />}
+          {feed.sos && <SOSFlag width="40px" />}
         </Styled.TitleWrapper>
         <Styled.Content>{feed.content}</Styled.Content>
-      </Styled.ContentArea>
+      </div>
     </Styled.Root>
   );
 };

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -39,7 +39,7 @@ const Home = () => {
         </Styled.SearchContainer>
 
         <Styled.ContentArea>
-          <Styled.SectionTitle fontSize="32px">Hot Toys</Styled.SectionTitle>
+          <Styled.SectionTitle fontSize="1.75rem">Hot Toys</Styled.SectionTitle>
           <Styled.HotToysContainer>
             <Styled.CarouselLeft width="24" />
             <Styled.HotToyCardsContainer>
@@ -56,7 +56,7 @@ const Home = () => {
             <Styled.CarouselRight width="24" />
           </Styled.HotToysContainer>
 
-          <Styled.SectionTitle fontSize="32px">Recent Toys</Styled.SectionTitle>
+          <Styled.SectionTitle fontSize="1.75rem">Recent Toys</Styled.SectionTitle>
           <Styled.RecentToysContainer>
             <Styled.LevelButtonsContainer>
               <LevelLinkButton.Progress />


### PR DESCRIPTION
## 작업 내용
refactor: StretchCard의 크기 작게 조정

## 스크린샷
(이렇게 보면 티는 안 남)

![image](https://user-images.githubusercontent.com/44080404/126024005-accc3238-b5bc-456b-af77-9c30285922fe.png)


## 주의사항
진행중, 조립중 태그 크기는 @0307kwon 미키가 수정 예정 