### PR TITLE
[FE] Upload 페이지 최소 구현 기능 완료

### DIFF
--- a/frontend/custom.d.ts
+++ b/frontend/custom.d.ts
@@ -1,9 +1,10 @@
 interface SVGProps {
+  fill?: string;
   width: string;
 }
 
 declare module '*.svg' {
-  const content: ({ width }: SVGProps) => JSX.Element;
+  const content: ({ fill, width }: SVGProps) => JSX.Element;
 
   export default content;
 }

--- a/frontend/src/assets/arrowUp.svg
+++ b/frontend/src/assets/arrowUp.svg
@@ -1,0 +1,3 @@
+<svg width="current" height="current" viewBox="0 0 12 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 0L11.1962 9H0.803848L6 0Z" fill="current"/>
+</svg>

--- a/frontend/src/components/@common/ErrorMessage/ErrorMessage.stories.tsx
+++ b/frontend/src/components/@common/ErrorMessage/ErrorMessage.stories.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import FormInput from '../FormInput/FormInput';
+import Label from '../Label/Label';
+
+import ErrorMessage from './ErrorMessage';
+
+export default {
+  title: 'components/common/ErrorMessage',
+  component: ErrorMessage,
+  argTypes: {},
+};
+
+export const Progress = () => {
+  const {
+    register,
+    setError,
+    formState: { errors },
+  } = useForm<{ title: string }>();
+
+  setError('title', {
+    type: 'required',
+    message: '😭 프로젝트 이름을 알려주세요!',
+  });
+
+  return (
+    <div>
+      <Label text="제목" required={true} />
+      <FormInput
+        {...register('title', {
+          required: '😭 프로젝트 이름을 알려주세요!',
+        })}
+      />
+      <ErrorMessage targetError={errors.title} />
+    </div>
+  );
+};

--- a/frontend/src/components/@common/ErrorMessage/ErrorMessage.styles.ts
+++ b/frontend/src/components/@common/ErrorMessage/ErrorMessage.styles.ts
@@ -1,0 +1,62 @@
+import { PALETTE } from 'constants/palette';
+import styled, { keyframes } from 'styled-components';
+import ArrowUpSvg from 'assets/arrowUp.svg';
+
+const Root = styled.div`
+  display: inline-block;
+  width: 100%;
+`;
+
+const BACKGROUND_COLOR = PALETTE.BLACK_300;
+const OPACITY_ANIMATION_TIME = '0.5s';
+
+const opacityAnimation = keyframes`
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity : 1;
+  }
+`;
+
+const Background = styled.div`
+  position: absolute;
+  display: inline-block;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: ${BACKGROUND_COLOR};
+  border-radius: 5px;
+
+  animation: ${opacityAnimation} ${OPACITY_ANIMATION_TIME} ease;
+`;
+
+const Message = styled.div`
+  position: relative;
+  display: flex;
+  height: 2rem;
+  align-items: center;
+  padding-left: 0.5rem;
+
+  & > span {
+    z-index: 1;
+    color: ${PALETTE.WHITE_400};
+  }
+`;
+
+const ArrowUpWrapper = styled.div`
+  height: 0.85rem;
+  padding-left: 0.5rem;
+
+  & > svg {
+    fill: ${BACKGROUND_COLOR};
+  }
+
+  animation: ${opacityAnimation} ${OPACITY_ANIMATION_TIME} ease;
+`;
+
+const ArrowUp = styled(ArrowUpSvg)``;
+
+export default { Root, Message, Background, ArrowUpWrapper, ArrowUp };

--- a/frontend/src/components/@common/ErrorMessage/ErrorMessage.tsx
+++ b/frontend/src/components/@common/ErrorMessage/ErrorMessage.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { FieldError } from 'react-hook-form';
 
 import Styled from './ErrorMessage.styles';
-import { PALETTE } from 'constants/palette';
 
 interface Props {
   targetError: FieldError;
@@ -21,7 +20,7 @@ const ErrorMessage = ({ targetError, className }: Props) => {
       </Styled.ArrowUpWrapper>
       <Styled.Message>
         <Styled.Background></Styled.Background>
-        <span>{`${targetError.message}`}</span>
+        <span>{targetError.message}</span>
       </Styled.Message>
     </Styled.Root>
   );

--- a/frontend/src/components/@common/ErrorMessage/ErrorMessage.tsx
+++ b/frontend/src/components/@common/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { FieldError } from 'react-hook-form';
+
+import Styled from './ErrorMessage.styles';
+import { PALETTE } from 'constants/palette';
+
+interface Props {
+  targetError: FieldError;
+  className?: string;
+}
+
+const ErrorMessage = ({ targetError, className }: Props) => {
+  if (!targetError?.type) {
+    return null;
+  }
+
+  return (
+    <Styled.Root className={className}>
+      <Styled.ArrowUpWrapper>
+        <Styled.ArrowUp width="0.75rem" />
+      </Styled.ArrowUpWrapper>
+      <Styled.Message>
+        <Styled.Background></Styled.Background>
+        <span>{`${targetError.message}`}</span>
+      </Styled.Message>
+    </Styled.Root>
+  );
+};
+
+export default ErrorMessage;

--- a/frontend/src/components/@common/FileInput/FileInput.styles.ts
+++ b/frontend/src/components/@common/FileInput/FileInput.styles.ts
@@ -21,6 +21,7 @@ const Label = styled.label`
 
   & > span {
     display: flex;
+    position: relative;
     justify-content: center;
     align-items: center;
     color: ${PALETTE.WHITE_400};
@@ -28,6 +29,17 @@ const Label = styled.label`
     height: 2rem;
     background-color: ${PALETTE.PRIMARY_400};
     border-radius: 4px;
+    overflow: hidden;
+
+    &:hover::after {
+      content: '';
+      display: block;
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      background-color: ${PALETTE.BLACK_400};
+      opacity: 0.1;
+    }
   }
 
   cursor: pointer;

--- a/frontend/src/components/@common/Toggle/Toggle.styles.ts
+++ b/frontend/src/components/@common/Toggle/Toggle.styles.ts
@@ -17,6 +17,7 @@ const Text = styled.span`
 const ToggleMark = styled.span`
   position: relative;
   width: 2.5rem;
+  min-width: 2.5rem;
   height: 1.5rem;
   border-radius: 25px;
   display: flex;

--- a/frontend/src/components/TechInput/TechInput.styles.ts
+++ b/frontend/src/components/TechInput/TechInput.styles.ts
@@ -41,7 +41,7 @@ const TechOption = styled.li<{ focused?: boolean }>`
 `;
 
 const TechButtonsContainer = styled.div`
-  margin-bottom: 0.25rem;
+  margin: 0.25rem 0;
   width: 100%;
   display: flex;
   flex-wrap: wrap;
@@ -51,7 +51,7 @@ export const TechButton = styled(TextButton.Rounded)`
   width: fit-content;
   height: 1.5rem;
   padding: 0 0.5rem;
-  margin-right: 0.25rem;
+  margin: 0.125rem 0.125rem;
 `;
 
 export default { Root, Dropdown, TechOption, TechButtonsContainer };

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -4,7 +4,7 @@ const api = axios.create({
   baseURL: 'https://nolto.kro.kr',
   headers: {
     Authorization:
-      'bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMUBlbWFpbC5jb20iLCJpYXQiOjE2MjYzNTM5MzMsImV4cCI6MTYyNjM1NzUzM30.FV6rawx-3CY3ETvIp1tmBsbS1vcKq4pcuzk4aBC8Kcg',
+      'bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMUBlbWFpbC5jb20iLCJpYXQiOjE2MjY1MDY5MzcsImV4cCI6MTYyNjUxMDUzN30.Ysz8YpzxUOQZYBNMTG5yJREuVuxdg0Atlqx1x_MCUa4',
   },
 });
 

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -1,0 +1,15 @@
+export const UPLOAD_VALIDATION_MSG = {
+  TITLE_REQUIRED: '😭 프로젝트 이름을 알려주세요!',
+  CONTENT_REQUIRED: '😁 프로젝트를 소개해주세요!',
+  STEP_REQUIRED: '🙋‍♂️ 프로젝트의 완성도는 어느 정도인가요?',
+  DEPLOY_URL_REQUIRED: '😎 전시중 프로젝트는 배포 URL이 필수예요!',
+  INVALID_URL: '🧡 올바른 url 형식을 사용해주세요!',
+};
+
+export const ALERT_MSG = {
+  SUCCESS_UPLOAD_FEED: '🎉 토이 프로젝트 등록에 성공했습니다!',
+};
+
+export const CONFIRM_MSG = {
+  LEAVE_UPLOAD_PAGE: '정말로 페이지를 떠나시겠습니까? 작성 중인 정보는 사라집니다.',
+};

--- a/frontend/src/pages/Upload/Upload.styles.ts
+++ b/frontend/src/pages/Upload/Upload.styles.ts
@@ -21,12 +21,18 @@ const TitleWrapper = styled.h2`
   margin-bottom: 3rem;
 `;
 
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 5rem;
+`;
+
 const VerticalWrapper = styled.div`
   display: flex;
   flex-direction: column;
   border-bottom: 2rem;
   width: 100%;
-  margin-bottom: 0.75rem;
 `;
 
 export const ContentTextArea = styled(TextArea)`
@@ -37,21 +43,24 @@ const InputsContainer = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
-  margin-bottom: 1rem;
+  justify-content: space-between;
 `;
 
 const StretchWrapper = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 1.5rem;
   border-bottom: 2rem;
   width: 100%;
-  margin-bottom: 1rem;
 
   & > .stretch-label {
-    width: 10rem;
+    min-width: 7rem;
   }
+`;
+
+const levelWrapper = styled(StretchWrapper)`
+  margin-bottom: 0;
+  width: auto;
 `;
 
 export const StyledButton = styled(TextButton.Regular)`
@@ -64,7 +73,6 @@ export const StyledButton = styled(TextButton.Regular)`
 const ButtonsWrapper = styled.div`
   display: flex;
   gap: 1.5rem;
-  margin: 2rem 0 5.5rem;
   justify-content: flex-end;
 `;
 
@@ -74,5 +82,6 @@ export default {
   VerticalWrapper,
   InputsContainer,
   StretchWrapper,
+  levelWrapper,
   ButtonsWrapper,
 };

--- a/frontend/src/pages/Upload/Upload.styles.ts
+++ b/frontend/src/pages/Upload/Upload.styles.ts
@@ -55,15 +55,17 @@ const StretchWrapper = styled.div`
 `;
 
 export const StyledButton = styled(TextButton.Regular)`
-  width: 19.5rem;
-  height: 4.25rem;
-  font-size: 1.75rem;
+  width: 5rem;
+  height: 2rem;
+  font-size: 1rem;
+  border-radius: 7px;
 `;
 
 const ButtonsWrapper = styled.div`
   display: flex;
-  gap: 2.75rem;
-  margin: 10.25rem 0 5.5rem;
+  gap: 1.5rem;
+  margin: 2rem 0 5.5rem;
+  justify-content: flex-end;
 `;
 
 export default {

--- a/frontend/src/pages/Upload/Upload.tsx
+++ b/frontend/src/pages/Upload/Upload.tsx
@@ -16,6 +16,7 @@ import { ButtonStyle, FeedStatus, Tech, FeedToUpload } from 'types';
 import ErrorMessage from 'components/@common/ErrorMessage/ErrorMessage';
 import { useHistory } from 'react-router-dom';
 import ROUTE from 'constants/routes';
+import { ALERT_MSG, CONFIRM_MSG, UPLOAD_VALIDATION_MSG } from 'constants/message';
 
 type FeedToUploadPartial = Omit<FeedToUpload, 'techs'>;
 
@@ -56,14 +57,14 @@ const Upload = () => {
 
     uploadMutation.mutate(formData, {
       onSuccess: () => {
-        alert('🎉 토이 프로젝트 등록에 성공했습니다!');
+        alert(ALERT_MSG.SUCCESS_UPLOAD_FEED);
         history.push(ROUTE.HOME);
       },
     });
   };
 
   const handleCancelUpload = () => {
-    if (!confirm('정말로 페이지를 떠나시겠습니까? 작성 중인 정보는 사라집니다.')) {
+    if (!confirm(CONFIRM_MSG.LEAVE_UPLOAD_PAGE)) {
       return;
     }
 
@@ -83,7 +84,7 @@ const Upload = () => {
             <Label text="제목" required={true} />
             <FormInput
               {...register('title', {
-                required: '😭 프로젝트 이름을 알려주세요!',
+                required: UPLOAD_VALIDATION_MSG.TITLE_REQUIRED,
               })}
             />
             <ErrorMessage targetError={errors.title} />
@@ -97,7 +98,7 @@ const Upload = () => {
           <Styled.VerticalWrapper>
             <Label text="내용" required={true} />
             <ContentTextArea
-              {...register('content', { required: '😁 프로젝트를 소개해주세요!' })}
+              {...register('content', { required: UPLOAD_VALIDATION_MSG.CONTENT_REQUIRED })}
             />
             <ErrorMessage targetError={errors.content} />
           </Styled.VerticalWrapper>
@@ -111,7 +112,7 @@ const Upload = () => {
                     name="step"
                     labelText="🧩 조립중"
                     value={FeedStatus.PROGRESS}
-                    {...register('step', { required: '🙋‍♂️ 프로젝트의 완성도는 어느 정도인가요?' })}
+                    {...register('step', { required: UPLOAD_VALIDATION_MSG.STEP_REQUIRED })}
                   />
                   <RadioButton
                     name="step"
@@ -133,11 +134,11 @@ const Upload = () => {
                 <Label className="stretch-label" text="배포 URL" required={true} />
                 <FormInput
                   {...register('deployedUrl', {
-                    required: '😎 전시중 프로젝트는 배포 URL이 필수예요!',
+                    required: UPLOAD_VALIDATION_MSG.DEPLOY_URL_REQUIRED,
                     pattern: {
                       value:
                         /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/,
-                      message: '🧡 올바른 url 형식을 사용해주세요!',
+                      message: UPLOAD_VALIDATION_MSG.INVALID_URL,
                     },
                   })}
                 />
@@ -153,7 +154,7 @@ const Upload = () => {
                   pattern: {
                     value:
                       /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/,
-                    message: '🧡 올바른 url 형식을 사용해주세요!',
+                    message: UPLOAD_VALIDATION_MSG.INVALID_URL,
                   },
                 })}
               />

--- a/frontend/src/pages/Upload/Upload.tsx
+++ b/frontend/src/pages/Upload/Upload.tsx
@@ -11,15 +11,25 @@ import Header from 'components/Header/Header';
 import TechInput from 'components/TechInput/TechInput';
 import useUploadFeed from 'hooks/queries/useUploadFeed';
 import { FlexContainer } from 'commonStyles';
-import Styled, { ContentTextArea, StyledButton } from './Upload.styles';
+import Styled, { ContentTextArea, Form, StyledButton } from './Upload.styles';
 import { ButtonStyle, FeedStatus, Tech, FeedToUpload } from 'types';
+import ErrorMessage from 'components/@common/ErrorMessage/ErrorMessage';
 
 type FeedToUploadPartial = Omit<FeedToUpload, 'techs'>;
 
 const Upload = () => {
-  const { register, handleSubmit, setValue, watch } = useForm<FeedToUploadPartial>();
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<FeedToUploadPartial>({
+    shouldUnregister: true,
+  });
   const [techs, setTechs] = useState<Tech[]>([]);
   const watchThumbnailImage = watch('thumbnailImage');
+  const watchStep = watch('step');
   const uploadMutation = useUploadFeed();
 
   const uploadFeed = (data: FeedToUploadPartial) => {
@@ -52,10 +62,15 @@ const Upload = () => {
           <HighLightedText fontSize="1.75rem">🦄 Upload Your Toy</HighLightedText>
         </Styled.TitleWrapper>
 
-        <form onSubmit={handleSubmit(uploadFeed)}>
+        <Form onSubmit={handleSubmit(uploadFeed)}>
           <Styled.VerticalWrapper>
             <Label text="제목" required={true} />
-            <FormInput {...register('title', { required: true })} />
+            <FormInput
+              {...register('title', {
+                required: '😭 프로젝트 이름을 알려주세요!',
+              })}
+            />
+            <ErrorMessage targetError={errors.title} />
           </Styled.VerticalWrapper>
 
           <Styled.VerticalWrapper>
@@ -65,40 +80,70 @@ const Upload = () => {
 
           <Styled.VerticalWrapper>
             <Label text="내용" required={true} />
-            <ContentTextArea {...register('content', { required: true })} />
+            <ContentTextArea
+              {...register('content', { required: '😁 프로젝트를 소개해주세요!' })}
+            />
+            <ErrorMessage targetError={errors.content} />
           </Styled.VerticalWrapper>
 
-          <Styled.InputsContainer>
+          <div>
+            <Styled.InputsContainer>
+              <Styled.levelWrapper>
+                <Label className="stretch-label" text="레벨" required={true} />
+                <FlexContainer>
+                  <RadioButton
+                    name="step"
+                    labelText="🧩 조립중"
+                    value={FeedStatus.PROGRESS}
+                    {...register('step', { required: '🙋‍♂️ 프로젝트의 완성도는 어느 정도인가요?' })}
+                  />
+                  <RadioButton
+                    name="step"
+                    labelText="🦄 전시중"
+                    value={FeedStatus.COMPLETE}
+                    {...register('step')}
+                  />
+                </FlexContainer>
+              </Styled.levelWrapper>
+
+              <Toggle labelText="🚨 SOS" {...register('sos')} />
+            </Styled.InputsContainer>
+            <ErrorMessage targetError={errors.step} />
+          </div>
+
+          {watchStep === FeedStatus.COMPLETE && (
+            <div>
+              <Styled.StretchWrapper>
+                <Label className="stretch-label" text="배포 URL" required={true} />
+                <FormInput
+                  {...register('deployedUrl', {
+                    required: '😎 전시중 프로젝트는 배포 URL이 필수예요!',
+                    pattern: {
+                      value:
+                        /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/,
+                      message: '🧡 올바른 url 형식을 사용해주세요!',
+                    },
+                  })}
+                />
+              </Styled.StretchWrapper>
+              <ErrorMessage targetError={errors.deployedUrl} />
+            </div>
+          )}
+          <div>
             <Styled.StretchWrapper>
-              <Label className="stretch-label" text="레벨" required={true} />
-              <FlexContainer width="100%">
-                <RadioButton
-                  name="step"
-                  labelText="🧩 조립중"
-                  value={FeedStatus.PROGRESS}
-                  {...register('step', { required: true })}
-                />
-                <RadioButton
-                  name="step"
-                  labelText="🦄 전시중"
-                  value={FeedStatus.COMPLETE}
-                  {...register('step', { required: true })}
-                />
-              </FlexContainer>
+              <Label className="stretch-label" text="github URL" />
+              <FormInput
+                {...register('storageUrl', {
+                  pattern: {
+                    value:
+                      /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/,
+                    message: '🧡 올바른 url 형식을 사용해주세요!',
+                  },
+                })}
+              />
             </Styled.StretchWrapper>
-
-            <Toggle labelText="🚨 SOS" {...register('sos')} />
-          </Styled.InputsContainer>
-
-          <Styled.StretchWrapper>
-            <Label className="stretch-label" text="github" required={true} />
-            <FormInput {...register('storageUrl', { required: true })} />
-          </Styled.StretchWrapper>
-
-          <Styled.StretchWrapper>
-            <Label className="stretch-label" text="배포 URL" required={true} />
-            <FormInput {...register('deployedUrl', { required: true })} />
-          </Styled.StretchWrapper>
+            <ErrorMessage targetError={errors.storageUrl} />
+          </div>
 
           <Styled.StretchWrapper>
             <Label className="stretch-label" text="대표 이미지" />
@@ -114,7 +159,7 @@ const Upload = () => {
               취소
             </StyledButton>
           </Styled.ButtonsWrapper>
-        </form>
+        </Form>
       </Styled.Root>
     </>
   );

--- a/frontend/src/pages/Upload/Upload.tsx
+++ b/frontend/src/pages/Upload/Upload.tsx
@@ -25,11 +25,15 @@ const Upload = () => {
   const uploadFeed = (data: FeedToUploadPartial) => {
     const formData = new FormData();
 
-    Object.keys(data).forEach((key) => {
+    Object.keys(data).forEach((key: keyof typeof data) => {
+      if (!data[key]) {
+        return;
+      }
+
       if (key === 'thumbnailImage') {
         formData.append(key, data[key]);
       } else {
-        formData.append(key, String(data[key as keyof typeof data]));
+        formData.append(key, String(data[key]));
       }
     });
 

--- a/frontend/src/pages/Upload/Upload.tsx
+++ b/frontend/src/pages/Upload/Upload.tsx
@@ -20,6 +20,9 @@ import { ALERT_MSG, CONFIRM_MSG, UPLOAD_VALIDATION_MSG } from 'constants/message
 
 type FeedToUploadPartial = Omit<FeedToUpload, 'techs'>;
 
+const URL_REGEX =
+  /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/;
+
 const Upload = () => {
   const {
     register,
@@ -40,9 +43,7 @@ const Upload = () => {
     const formData = new FormData();
 
     Object.keys(data).forEach((key: keyof typeof data) => {
-      if (!data[key]) {
-        return;
-      }
+      if (!data[key]) return;
 
       if (key === 'thumbnailImage') {
         formData.append(key, data[key]);
@@ -64,9 +65,7 @@ const Upload = () => {
   };
 
   const handleCancelUpload = () => {
-    if (!confirm(CONFIRM_MSG.LEAVE_UPLOAD_PAGE)) {
-      return;
-    }
+    if (!confirm(CONFIRM_MSG.LEAVE_UPLOAD_PAGE)) return;
 
     history.goBack();
   };
@@ -136,8 +135,7 @@ const Upload = () => {
                   {...register('deployedUrl', {
                     required: UPLOAD_VALIDATION_MSG.DEPLOY_URL_REQUIRED,
                     pattern: {
-                      value:
-                        /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/,
+                      value: URL_REGEX,
                       message: UPLOAD_VALIDATION_MSG.INVALID_URL,
                     },
                   })}
@@ -152,8 +150,7 @@ const Upload = () => {
               <FormInput
                 {...register('storageUrl', {
                   pattern: {
-                    value:
-                      /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/,
+                    value: URL_REGEX,
                     message: UPLOAD_VALIDATION_MSG.INVALID_URL,
                   },
                 })}

--- a/frontend/src/pages/Upload/Upload.tsx
+++ b/frontend/src/pages/Upload/Upload.tsx
@@ -14,6 +14,8 @@ import { FlexContainer } from 'commonStyles';
 import Styled, { ContentTextArea, Form, StyledButton } from './Upload.styles';
 import { ButtonStyle, FeedStatus, Tech, FeedToUpload } from 'types';
 import ErrorMessage from 'components/@common/ErrorMessage/ErrorMessage';
+import { useHistory } from 'react-router-dom';
+import ROUTE from 'constants/routes';
 
 type FeedToUploadPartial = Omit<FeedToUpload, 'techs'>;
 
@@ -31,6 +33,7 @@ const Upload = () => {
   const watchThumbnailImage = watch('thumbnailImage');
   const watchStep = watch('step');
   const uploadMutation = useUploadFeed();
+  const history = useHistory();
 
   const uploadFeed = (data: FeedToUploadPartial) => {
     const formData = new FormData();
@@ -51,7 +54,20 @@ const Upload = () => {
       formData.append('techs', String(tech.id));
     });
 
-    uploadMutation.mutate(formData);
+    uploadMutation.mutate(formData, {
+      onSuccess: () => {
+        alert('🎉 토이 프로젝트 등록에 성공했습니다!');
+        history.push(ROUTE.HOME);
+      },
+    });
+  };
+
+  const handleCancelUpload = () => {
+    if (!confirm('정말로 페이지를 떠나시겠습니까? 작성 중인 정보는 사라집니다.')) {
+      return;
+    }
+
+    history.goBack();
   };
 
   return (
@@ -155,7 +171,11 @@ const Upload = () => {
 
           <Styled.ButtonsWrapper>
             <StyledButton buttonStyle={ButtonStyle.SOLID}>등록</StyledButton>
-            <StyledButton type="button" buttonStyle={ButtonStyle.OUTLINE}>
+            <StyledButton
+              onClick={handleCancelUpload}
+              type="button"
+              buttonStyle={ButtonStyle.OUTLINE}
+            >
               취소
             </StyledButton>
           </Styled.ButtonsWrapper>


### PR DESCRIPTION
## 작업 내용
작업하다가 뒤늦게 브랜치를 나누지 않았다는 사실을 알았습니다ㅠ
뒤늦게 깨닫고 나누려고 했지만 너무 관계가 밀접해서 나누지 못했습니다
PR이 너무 커진점... 반성하겠습니다 😭

추가된 대략적인 기능들
- validation
- redirection
- svg에 fill 속성으로 색을 변경할 수 있도록 수정
- UploadFeed 타이핑도 다시 살짝 수정하였습니다.

Closes #144 

## 스크린샷
![GIF 2021-07-17 오후 10-40-36](https://user-images.githubusercontent.com/48755175/126038956-dc05a670-3750-40ac-91b3-aa6a16993168.gif)

## 주의사항
이쁨

근데 문제점이 2가지 있습니다.
1. text area에 개행을 넣으면 게시물 등록이 안됩니다.
2. 대표 이미지는 옵셔널 아니었나용? 지금 대표 이미지가 없으면 등록이 안됩니다.
