### PR TITLE
[FE] fix: ErrorMesage 폰트 크기, 레이아웃 수정

### DIFF
--- a/frontend/src/components/@common/ErrorMessage/ErrorMessage.styles.ts
+++ b/frontend/src/components/@common/ErrorMessage/ErrorMessage.styles.ts
@@ -4,7 +4,9 @@ import ArrowUpSvg from 'assets/arrowUp.svg';
 
 const Root = styled.div`
   display: inline-block;
+  position: relative;
   width: 100%;
+  padding-top: 1rem;
 `;
 
 const BACKGROUND_COLOR = PALETTE.BLACK_300;
@@ -42,13 +44,15 @@ const Message = styled.div`
 
   & > span {
     z-index: 1;
+    font-size: 0.75rem;
     color: ${PALETTE.WHITE_400};
   }
 `;
 
 const ArrowUpWrapper = styled.div`
-  height: 0.85rem;
+  position: absolute;
   padding-left: 0.5rem;
+  top: 0;
 
   & > svg {
     fill: ${BACKGROUND_COLOR};


### PR DESCRIPTION
## 작업 내용

- ErrorMessage 폰트 크기 0.75rem으로 수정
- 말풍선 arrow 위치 수정 => **맥에서 확인해주세요!!**

Closes #155

## 스크린샷
![image](https://user-images.githubusercontent.com/48755175/126065020-a11ff84f-c7b2-4cf4-a048-bf5b75ccd6a5.png)
