### PR TITLE
[FE] fix: mac에서 ErrorMessage 스타일링 깨지는 버그 수정

### DIFF
--- a/frontend/src/components/@common/ErrorMessage/ErrorMessage.styles.ts
+++ b/frontend/src/components/@common/ErrorMessage/ErrorMessage.styles.ts
@@ -1,12 +1,13 @@
-import { PALETTE } from 'constants/palette';
 import styled, { keyframes } from 'styled-components';
-import ArrowUpSvg from 'assets/arrowUp.svg';
+
+import { PALETTE } from 'constants/palette';
+import ArrowUp from 'assets/arrowUp.svg';
 
 const Root = styled.div`
   display: inline-block;
   position: relative;
   width: 100%;
-  padding-top: 1rem;
+  padding-top: 0.25rem;
 `;
 
 const BACKGROUND_COLOR = PALETTE.BLACK_300;
@@ -22,24 +23,16 @@ const opacityAnimation = keyframes`
   }
 `;
 
-const Background = styled.div`
-  position: absolute;
-  display: inline-block;
-  top: 0;
-  left: 0;
+const Message = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
   width: 100%;
-  height: 100%;
+  height: 1.75rem;
   background-color: ${BACKGROUND_COLOR};
   border-radius: 5px;
 
   animation: ${opacityAnimation} ${OPACITY_ANIMATION_TIME} ease;
-`;
-
-const Message = styled.div`
-  position: relative;
-  display: flex;
-  height: 2rem;
-  align-items: center;
   padding-left: 0.5rem;
 
   & > span {
@@ -49,18 +42,12 @@ const Message = styled.div`
   }
 `;
 
-const ArrowUpWrapper = styled.div`
-  position: absolute;
+const ArrowUpIcon = styled(ArrowUp)`
   padding-left: 0.5rem;
-  top: 0;
-
-  & > svg {
-    fill: ${BACKGROUND_COLOR};
-  }
+  fill: ${BACKGROUND_COLOR};
+  display: block;
 
   animation: ${opacityAnimation} ${OPACITY_ANIMATION_TIME} ease;
 `;
 
-const ArrowUp = styled(ArrowUpSvg)``;
-
-export default { Root, Message, Background, ArrowUpWrapper, ArrowUp };
+export default { Root, Message, ArrowUpIcon };

--- a/frontend/src/components/@common/ErrorMessage/ErrorMessage.tsx
+++ b/frontend/src/components/@common/ErrorMessage/ErrorMessage.tsx
@@ -15,11 +15,8 @@ const ErrorMessage = ({ targetError, className }: Props) => {
 
   return (
     <Styled.Root className={className}>
-      <Styled.ArrowUpWrapper>
-        <Styled.ArrowUp width="0.75rem" />
-      </Styled.ArrowUpWrapper>
+      <Styled.ArrowUpIcon width="1rem" />
       <Styled.Message>
-        <Styled.Background></Styled.Background>
         <span>{targetError.message}</span>
       </Styled.Message>
     </Styled.Root>


### PR DESCRIPTION
## 작업 내용
mac에서 ErrorMessage 스타일링 깨지는 버그 수정

Closes #167

## 스크린샷
![image](https://user-images.githubusercontent.com/44080404/126089413-d38cf781-72b6-46c8-bd03-8f7d5ae65504.png)


## 주의사항
- 구조 많이 바꿈
- height 좀 더 줄여도 될 것 같아서 (원래 상태의 input과 error box의 크기가 비슷해서 중요도가 같아 보임) 조금 줄임
