### PR TITLE
[FE] feat: Notification (Provider) 컴포넌트 구현

### DIFF
--- a/frontend/.storybook/preview-body.html
+++ b/frontend/.storybook/preview-body.html
@@ -1,2 +1,3 @@
 <div id="modal-root"></div>
 <div id="snackbar-root"></div>
+<div id="notification-root"></div>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -10,5 +10,6 @@
     <div id="root"></div>
     <div id="modal-root"></div>
     <div id="snackbar-root"></div>
+    <div id="notification-root"></div>
   </body>
 </html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,11 +9,12 @@ import FeedDetail from 'pages/FeedDetail/FeedDetail';
 import RecentFeeds from 'pages/RecentFeeds/RecentFeeds';
 import OAuth from 'pages/OAuth/OAuth';
 import AsyncBoundary from 'components/AsyncBoundary';
+import NotificationProvider from 'context/notification/NotificationProvider';
 import UserInfoProvider from 'context/userInfo/UserInfoProvider';
-import ROUTE from 'constants/routes';
-import GlobalStyle from './Global.styles';
 import ModalProvider from 'context/modal/ModalProvider';
 import SnackBarProvider from 'context/snackBar/SnackBarProvider';
+import ROUTE from 'constants/routes';
+import GlobalStyle from './Global.styles';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -32,27 +33,29 @@ const App = () => {
         <Switch>
           <UserInfoProvider>
             <SnackBarProvider>
-              <ModalProvider>
-                <main>
-                  <Route exact path={ROUTE.HOME}>
-                    <AsyncBoundary rejectedFallback={<h1>임시 에러 페이지</h1>}>
-                      <Home />
-                    </AsyncBoundary>
-                  </Route>
-                  <Route path={ROUTE.UPLOAD}>
-                    <Upload />
-                  </Route>
-                  <Route exact path={ROUTE.FEEDS}>
-                    <RecentFeeds />
-                  </Route>
-                  <Route path={`${ROUTE.FEEDS}/:id`}>
-                    <FeedDetail />
-                  </Route>
-                  <Route path="/:oauth/callback">
-                    <OAuth />
-                  </Route>
-                </main>
-              </ModalProvider>
+              <NotificationProvider>
+                <ModalProvider>
+                  <main>
+                    <Route exact path={ROUTE.HOME}>
+                      <AsyncBoundary rejectedFallback={<h1>임시 에러 페이지</h1>}>
+                        <Home />
+                      </AsyncBoundary>
+                    </Route>
+                    <Route path={ROUTE.UPLOAD}>
+                      <Upload />
+                    </Route>
+                    <Route exact path={ROUTE.FEEDS}>
+                      <RecentFeeds />
+                    </Route>
+                    <Route path={`${ROUTE.FEEDS}/:id`}>
+                      <FeedDetail />
+                    </Route>
+                    <Route path="/:oauth/callback">
+                      <OAuth />
+                    </Route>
+                  </main>
+                </ModalProvider>
+              </NotificationProvider>
             </SnackBarProvider>
           </UserInfoProvider>
         </Switch>

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -7,10 +7,10 @@ import Pencil from 'assets/pencil.svg';
 import { PALETTE } from 'constants/palette';
 import ROUTE from 'constants/routes';
 import useModal from 'context/modal/useModal';
+import useUserInfo from 'hooks/useUserInfo';
 import LoginModal from 'components/LoginModal/LoginModal';
 import { ButtonStyle } from 'types';
 import Styled, { IconButton, SearchBar } from './Header.styles';
-import useUserInfo from 'hooks/useUserInfo';
 
 interface Props {
   isFolded?: boolean;

--- a/frontend/src/context/modal/ModalProvider.styles.ts
+++ b/frontend/src/context/modal/ModalProvider.styles.ts
@@ -13,7 +13,7 @@ const ModalContainer = styled.div`
   width: 100vw;
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.3);
-  z-index: 100;
+  z-index: 110;
 `;
 
 const ModalInner = styled.div`

--- a/frontend/src/context/notification/NotificationProvider.stories.tsx
+++ b/frontend/src/context/notification/NotificationProvider.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import NotificationProvider from './NotificationProvider';
+import useNotification from './useNotification';
+
+export default {
+  title: 'context/NotificationProvider',
+  component: NotificationProvider,
+  argTypes: {},
+};
+
+const Page = () => {
+  const notification = useNotification();
+
+  return (
+    <div>
+      <button onClick={() => notification.alert('alert 창인데요?')}>alert</button>
+      <button onClick={() => notification.confirm('confirm 창인데요?', () => console.log('성공!'))}>
+        confirm
+      </button>
+    </div>
+  );
+};
+
+export const Default = () => (
+  <NotificationProvider>
+    <Page />
+  </NotificationProvider>
+);

--- a/frontend/src/context/notification/NotificationProvider.styles.ts
+++ b/frontend/src/context/notification/NotificationProvider.styles.ts
@@ -1,0 +1,86 @@
+import styled, { keyframes } from 'styled-components';
+
+import { PALETTE } from 'constants/palette';
+import TextButton from 'components/@common/TextButton/TextButton';
+
+const show = keyframes`
+  from {
+    transform: scale(0.75);
+  }
+
+  to {
+    transform: scale(1.0);
+  }
+`;
+
+const NotiContainer = styled.div`
+  position: fixed;
+  display: flex;
+  justify-content: center;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.15);
+  z-index: 120;
+`;
+
+const NotiInner = styled.div`
+  animation: ${show} 0.1s ease;
+
+  width: 372px;
+  height: 218px;
+  border-radius: 8px;
+  background-color: ${PALETTE.WHITE_400};
+  box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+`;
+
+const TopBar = styled.div`
+  position: absolute;
+  display: flex;
+  top: 0;
+  width: 100%;
+  height: 40px;
+  background-color: ${PALETTE.PRIMARY_400};
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0.75rem;
+`;
+
+const AlertTitle = styled.span`
+  color: ${PALETTE.WHITE_400};
+`;
+
+const CrossMarkButton = styled.button`
+  border: none;
+  background: transparent;
+`;
+
+const ButtonsContainer = styled.div`
+  width: 100%;
+  position: absolute;
+  bottom: 1rem;
+  padding: 0 1rem;
+  display: flex;
+`;
+
+export const Button = styled(TextButton.Regular)<{ single?: boolean }>`
+  width: ${({ single }) => (single ? '50%' : '100%')};
+  margin: 0 ${({ single }) => (single ? 'auto' : '0.25rem')};
+  padding: 0.4rem 1rem;
+`;
+
+export default {
+  NotiContainer,
+  NotiInner,
+  TopBar,
+  AlertTitle,
+  CrossMarkButton,
+  ButtonsContainer,
+};

--- a/frontend/src/context/notification/NotificationProvider.tsx
+++ b/frontend/src/context/notification/NotificationProvider.tsx
@@ -1,0 +1,101 @@
+import React, { useMemo, useState } from 'react';
+import ReactDOM from 'react-dom';
+
+import Styled, { Button } from './NotificationProvider.styles';
+import CrossMark from 'assets/crossMark.svg';
+import { ButtonStyle, NotificationType } from 'types';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface NotificationContext {
+  alert: (message: string) => void;
+  confirm: (message: string, callback: OnConfirm) => void;
+}
+
+type OnConfirm = () => unknown;
+
+export const Context = React.createContext<NotificationContext>(null);
+
+const notificationRoot = document.getElementById('notification-root');
+
+const NotificationProvider = ({ children }: Props) => {
+  const [notiType, setNotiType] = useState<NotificationType>();
+  const [message, setMessage] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [onConfirm, setOnConfirm] = useState<OnConfirm | null>(null);
+
+  const alert = (msg: string) => {
+    setNotiType('alert');
+    setMessage(msg);
+    setIsOpen(true);
+  };
+
+  const confirm = (msg: string, callback: OnConfirm) => {
+    setNotiType('confirm');
+    setMessage(msg);
+    setIsOpen(true);
+    setOnConfirm(() => callback);
+  };
+
+  const closeNotification = () => {
+    setIsOpen(false);
+  };
+
+  const confirmNotification = () => {
+    if (onConfirm) {
+      onConfirm();
+    }
+
+    setIsOpen(false);
+  };
+
+  const cancelNotification = () => {
+    setIsOpen(false);
+  };
+
+  const contextValue = useMemo(() => ({ alert, confirm }), []);
+
+  const notiButtonMap = {
+    alert: (
+      <Button single buttonStyle={ButtonStyle.SOLID} onClick={confirmNotification}>
+        확인
+      </Button>
+    ),
+    confirm: (
+      <>
+        <Button buttonStyle={ButtonStyle.SOLID} onClick={confirmNotification}>
+          확인
+        </Button>
+        <Button buttonStyle={ButtonStyle.OUTLINE} onClick={cancelNotification}>
+          취소
+        </Button>
+      </>
+    ),
+  };
+
+  const notificationElement: React.ReactNode = (
+    <Styled.NotiContainer>
+      <Styled.NotiInner>
+        <Styled.TopBar>
+          <Styled.AlertTitle>알림</Styled.AlertTitle>
+          <Styled.CrossMarkButton onClick={closeNotification}>
+            <CrossMark width="16px" />
+          </Styled.CrossMarkButton>
+        </Styled.TopBar>
+        <div>{message}</div>
+        <Styled.ButtonsContainer>{notiButtonMap[notiType]}</Styled.ButtonsContainer>
+      </Styled.NotiInner>
+    </Styled.NotiContainer>
+  );
+
+  return (
+    <Context.Provider value={contextValue}>
+      {children}
+      {isOpen && ReactDOM.createPortal(notificationElement, notificationRoot)}
+    </Context.Provider>
+  );
+};
+
+export default NotificationProvider;

--- a/frontend/src/context/notification/useNotification.ts
+++ b/frontend/src/context/notification/useNotification.ts
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+
+import { Context } from './NotificationProvider';
+
+const useNotification = () => {
+  const context = useContext(Context);
+
+  if (!context) {
+    throw new Error('NotificationProvider 내부에서만 useModal hook을 사용할 수 있습니다.');
+  }
+
+  return context;
+};
+
+export default useNotification;

--- a/frontend/src/context/snackBar/SnackBarProvider.stories.tsx
+++ b/frontend/src/context/snackBar/SnackBarProvider.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 
 import SnackBarProvider from './SnackBarProvider';
-import { useSnackBar } from './useSnackBar';
+import useSnackBar from './useSnackBar';
 
 export default {
   title: 'context/SnackBarProvider',

--- a/frontend/src/context/snackBar/SnackBarProvider.styles.ts
+++ b/frontend/src/context/snackBar/SnackBarProvider.styles.ts
@@ -24,7 +24,7 @@ const SnackBarWrapper = styled.div`
   gap: 0.5rem;
   bottom: 1rem;
   left: 1rem;
-  z-index: 100;
+  z-index: 120;
 `;
 
 const SnackBar = styled.div<{ type: SnackBarType }>`

--- a/frontend/src/context/snackBar/useSnackBar.ts
+++ b/frontend/src/context/snackBar/useSnackBar.ts
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 
 import { Context } from './SnackBarProvider';
 
-export const useSnackBar = () => {
+const useSnackBar = () => {
   const context = useContext(Context);
 
   if (!context) {
@@ -11,3 +11,5 @@ export const useSnackBar = () => {
 
   return context;
 };
+
+export default useSnackBar;

--- a/frontend/src/context/techTag/input/TechInput.tsx
+++ b/frontend/src/context/techTag/input/TechInput.tsx
@@ -5,7 +5,7 @@ import useQueryDebounce from 'hooks/@common/useQueryDebounce';
 import FormInput from 'components/@common/FormInput/FormInput';
 import { Tech } from 'types';
 import Styled from './TechInput.styles';
-import { useTechTag } from '../useTechTag';
+import useTechTag from '../useTechTag';
 
 interface Props {
   onUpdateTechs: (techs: Tech[]) => void;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -59,3 +59,5 @@ export type OAuthType = 'google' | 'github';
 export type SnackBarType = 'error' | 'success' | null;
 
 export type AddSnackBar = (type: SnackBarType, text: string) => void;
+
+export type NotificationType = 'alert' | 'confirm';


### PR DESCRIPTION
## 작업 내용
- z-index 관계 조정 (modal, snackbar)
- Provider hooks -> export default 로 통일

Co-authored-by: Kwon Se-jin <0307kwon@users.noreply.github.com>

Closes #220

## 스크린샷
![notification](https://media.giphy.com/media/LtXZ93CWedMtewabug/giphy.gif)

## 주의사항
스토리북이 안 돌아감
`Target container is not a DOM element.`
에러 발생 