### PR TITLE
feed 업로드 시 이미지가 없으면 수정을 안하도록 수정

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -80,7 +80,7 @@ public class FeedService {
     }
 
     private void updateThumbnailIfImageExist(FeedRequest request, Feed findFeed) {
-        if (request.getThumbnailImage().isEmpty()) return;
+        if (imageService.isEmpty(request.getThumbnailImage())) return;
 
         String updateThumbnailUrl = imageService.update(findFeed.getThumbnailUrl(), request.getThumbnailImage());
         findFeed.changeThumbnailUrl(updateThumbnailUrl);

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -72,12 +72,18 @@ public class FeedService {
                 request.getDeployedUrl()
         );
 
-        String updateThumbnailUrl = imageService.update(findFeed.getThumbnailUrl(), request.getThumbnailImage());
-        findFeed.changeThumbnailUrl(updateThumbnailUrl);
+        updateThumbnailIfImageExist(request, findFeed);
 
         feedTechRepository.deleteAll(findFeed.getFeedTechs());
         List<FeedTech> feedTechs = makeTechIdToFeedTech(request, findFeed);
         findFeed.changeFeedTechs(feedTechs);
+    }
+
+    private void updateThumbnailIfImageExist(FeedRequest request, Feed findFeed) {
+        if (request.getThumbnailImage().isEmpty()) return;
+
+        String updateThumbnailUrl = imageService.update(findFeed.getThumbnailUrl(), request.getThumbnailImage());
+        findFeed.changeThumbnailUrl(updateThumbnailUrl);
     }
 
     public FeedResponse findById(User user, Long feedId) {

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
@@ -125,7 +125,7 @@ public class Feed extends BaseEntity {
     }
 
     public void changeThumbnailUrl(String updateThumbnailUrl) {
-        this.thumbnailUrl = thumbnailUrl;
+        this.thumbnailUrl = updateThumbnailUrl;
     }
 
     public void changeFeedTechs(List<FeedTech> feedTechs) {

--- a/backend/src/main/java/com/wooteco/nolto/image/application/ImageService.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/application/ImageService.java
@@ -36,7 +36,7 @@ public class ImageService {
     }
 
     public String upload(MultipartFile multipartFile) {
-        if (multipartFile.isEmpty()) {
+        if (isEmpty(multipartFile)) {
             return cloudfrontUrl + "/" + defaultImage;
         }
         File file = convertToFile(multipartFile);
@@ -44,6 +44,10 @@ public class ImageService {
         amazonS3Client.putObject(new PutObjectRequest(bucketName, fileName, file));
         file.delete();
         return cloudfrontUrl + "/" + fileName;
+    }
+
+    public boolean isEmpty(MultipartFile multipartFile) {
+        return Objects.isNull(multipartFile) || multipartFile.isEmpty();
     }
 
     private String getFileName(File file) {


### PR DESCRIPTION
## 작업 내용

- feed 등록 : 이미지가 없으면 디폴트 이미지로 설정
- feed 수정 : 이미지가 없으면 변경이 이루어지지 않도록 수정

## 주의사항

기존의 피드 등록 시 MultipartFile이 empty인 경우에만 디폴트 이미지를 설정해주고 있는데용
프론트에서 피드 요청 값 중 이미지 자체를 안 보내게 될 경우 null이 되기 때문에 이 부분에 대한 검증 로직을 추가해 디폴트 이미지로 설정해주었습니다.
