### PR TITLE
feat: 검색 기능에 필터링 기능 추가

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -119,9 +120,12 @@ public class FeedService {
         feedRepository.delete(findFeed);
     }
 
-    public List<FeedCardResponse> search(String query, String techs) {
-        SearchStrategy strategy = SearchStrategyFactory.of(query, techs).findStrategy();
-        Set<Feed> searchFeed = strategy.search(query, techs);
-        return FeedCardResponse.toList(searchFeed);
+    public List<FeedCardResponse> search(String query, String techs, String filter) {
+        SearchStrategy searchStrategy = SearchStrategyFactory.of(query, techs).findStrategy();
+        Set<Feed> searchFeed = searchStrategy.search(query, techs);
+
+        Feeds feeds = new Feeds(new ArrayList<>(searchFeed));
+        FilterStrategy filterStrategy = FilterStrategy.of(filter);
+        return FeedCardResponse.toList(feeds.filter(filterStrategy));
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -75,8 +75,9 @@ public class FeedController {
 
     @GetMapping("/search")
     public ResponseEntity<List<FeedCardResponse>> searchResponse(@RequestParam(required = false, defaultValue = "") String query,
-                                                                 @RequestParam(required = false, defaultValue = "") String techs) {
-        List<FeedCardResponse> feeds = feedService.search(query, techs);
+                                                                 @RequestParam(required = false, defaultValue = "") String techs,
+                                                                 @RequestParam(required = false, defaultValue = "all") String filter) {
+        List<FeedCardResponse> feeds = feedService.search(query, techs, filter);
         return ResponseEntity.ok(feeds);
     }
 }

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
@@ -295,7 +295,7 @@ class FeedServiceTest {
 
     @DisplayName("좋아요 개수가 같은 경우 최신 Feed를 가져온다.(피드1: 좋아요0개, 피드2: 좋아요2개, 피드3: 좋아요2개)")
     @Test
-    void findHotFeedsBySameDate() throws InterruptedException {
+    void findHotFeedsBySameDate() {
         // given
         Long firstFeedId = feedService.create(user1, FEED_REQUEST1);
         Long secondFeedId = feedService.create(user1, FEED_REQUEST2);


### PR DESCRIPTION
## 작업 내용
- 검색 기능에서 필터링을 포함하여 검색할 수 있도록 보강
- 프로덕션 코드 다음과 같이 보강
    - FeedController
    ```java
    @GetMapping("/search")
    public ResponseEntity<List<FeedCardResponse>> searchResponse(@RequestParam(required = false, defaultValue = "") String query,
                                                                 @RequestParam(required = false, defaultValue = "") String techs,
                                                                 @RequestParam(required = false, defaultValue = "all") String filter) {
        List<FeedCardResponse> feeds = feedService.search(query, techs, filter);
        return ResponseEntity.ok(feeds);
    }
    ```
    - FeedService
    ```java
    public List<FeedCardResponse> search(String query, String techs, String filter) {
        SearchStrategy searchStrategy = SearchStrategyFactory.of(query, techs).findStrategy();
        Set<Feed> searchFeed = searchStrategy.search(query, techs);
  
        Feeds feeds = new Feeds(new ArrayList<>(searchFeed));
        FilterStrategy filterStrategy = FilterStrategy.of(filter);
        return FeedCardResponse.toList(feeds.filter(filterStrategy));
    }
    ```

## 주의사항
- RestDocs 문서화가 안되어있음. 검색기능 API가 확정되면 작성할 예정