### PR TITLE
[BE] 좋아요 기능 리팩토링 및 버그 수정

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/feed/application/LikeService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/LikeService.java
@@ -23,14 +23,16 @@ public class LikeService {
         if (user.isLiked(findFeed)) {
             throw new BadRequestException(ErrorType.ALREADY_LIKED);
         }
-
-        likeRepository.save(new Like(user, findFeed));
+        user.addLike(new Like(user, findFeed));
     }
 
     public void deleteLike(User user, Long feedId) {
         Feed findFeed = feedService.findEntityById(feedId);
-        Like findLike = likeRepository.findByUserAndFeed(user, findFeed)
+        Like findLike = findFeed.findLikeBy(user)
                 .orElseThrow(() -> new BadRequestException(ErrorType.NOT_LIKED));
+
         likeRepository.delete(findLike);
+        findFeed.delete(findLike);
+        user.delete(findLike);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
@@ -15,6 +15,7 @@ import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -121,7 +122,7 @@ public class Feed extends BaseEntity {
     }
 
     public boolean notSameAuthor(User user) {
-        return author.notSameAs(user);
+        return !author.SameAs(user);
     }
 
     public void changeThumbnailUrl(String updateThumbnailUrl) {
@@ -130,6 +131,16 @@ public class Feed extends BaseEntity {
 
     public void changeFeedTechs(List<FeedTech> feedTechs) {
         this.feedTechs = feedTechs;
+    }
+
+    public Optional<Like> findLikeBy(User user) {
+        return likes.stream()
+                .filter(like -> like.SameAs(user))
+                .findAny();
+    }
+
+    public void delete(Like like) {
+        this.likes.remove(like);
     }
 
     @Override

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Like.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Like.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor
@@ -31,5 +32,22 @@ public class Like {
 
     public boolean hasFeed(Feed feed) {
         return this.feed.equals(feed);
+    }
+
+    public boolean SameAs(User user) {
+        return this.user.SameAs(user);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Like like = (Like) o;
+        return Objects.equals(id, like.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -55,7 +55,7 @@ public class FeedController {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/{feedId}/like")
+    @PostMapping("/{feedId}/unlike")
     public ResponseEntity<Void> deleteLike(@MemberAuthenticationPrincipal User user, @PathVariable Long feedId) {
         likeService.deleteLike(user, feedId);
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -41,7 +41,7 @@ public class User {
     @OneToMany(mappedBy = "author")
     private final List<Feed> feeds = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private final List<Like> likes = new ArrayList<>();
 
     public User(String socialId, SocialType socialType, String nickName, String imageUrl) {
@@ -66,8 +66,16 @@ public class User {
         this.feeds.add(feed);
     }
 
-    public boolean notSameAs(User user) {
-        return !getId().equals(user.getId());
+    public void addLike(Like like) {
+        this.likes.add(like);
+    }
+
+    public boolean SameAs(User user) {
+        return getId().equals(user.getId());
+    }
+
+    public void delete(Like like) {
+        this.likes.remove(like);
     }
 
     private static class GuestUser extends User {

--- a/backend/src/test/java/com/wooteco/nolto/api/FeedControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/FeedControllerTest.java
@@ -293,7 +293,7 @@ public class FeedControllerTest extends ControllerTest {
         given(authService.findUserByToken(ACCESS_TOKEN)).willReturn(LOGIN_USER);
         willDoNothing().given(likeService).deleteLike(LOGIN_USER, FEED_ID);
 
-        mockMvc.perform(delete("/feeds/{feedId}/like", FEED_ID)
+        mockMvc.perform(post("/feeds/{feedId}/unlike", FEED_ID)
                 .header("Authorization", "Bearer " + ACCESS_TOKEN)
                 .characterEncoding("UTF-8"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## 작업 내용

### 피드 조회 시 해당 유저가 좋아요를 눌렀는지 확인하는 로직 수정 

- Feed - Like - User 사이에서 좋아요 Cascade를 적용할 수 있도록 수정
- 피드가 삭제되는 경우 해당 피드를 좋아요한 유저도 Like 데이터 삭제
- 유저가 삭제되는 경우 유저가 좋아요 누른 피드들의 Like 데이터 삭제

- 해당 유저의 좋아요 유무 출력에 대한 테스트 코드 작성
- user 비교 메서드 notSameAs()를 재활용성을 높이기 위해 SameAs()로 변경
- Closes #210 

### 좋아요 취소 API 명세 수정

- Close #211 

## 주의사항

- Like 삭제 시 id를 통해 동등성 체크를 할 수 있도록 equals(), hashCode() 추가
