### PR TITLE
test: User 인수 테스트 작성

### DIFF
--- a/backend/src/test/java/com/wooteco/nolto/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/acceptance/AcceptanceTest.java
@@ -6,6 +6,7 @@ import com.wooteco.nolto.auth.ui.dto.TokenResponse;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
 import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,17 +27,22 @@ public class AcceptanceTest {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
+    public static User 엄청난_유저 = new User(
+            "1",
+            SocialType.GITHUB,
+            "엄청난 유저",
+            "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png");
+
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
     }
 
+    public RequestSpecification given() {
+        return RestAssured.given().port(port);
+    }
+
     public TokenResponse 가입된_유저의_토큰을_받는다() {
-        User 엄청난_유저 = new User(
-                "1",
-                SocialType.GITHUB,
-                "엄청난 유저",
-                "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png");
         User 저장된_엄청난_유저 = userRepository.save(엄청난_유저);
 
         String token = jwtTokenProvider.createToken(String.valueOf(저장된_엄청난_유저.getId()));

--- a/backend/src/test/java/com/wooteco/nolto/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/acceptance/AcceptanceTest.java
@@ -27,7 +27,7 @@ public class AcceptanceTest {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
-    public static User 엄청난_유저 = new User(
+    public User 엄청난_유저 = new User(
             "1",
             SocialType.GITHUB,
             "엄청난 유저",

--- a/backend/src/test/java/com/wooteco/nolto/acceptance/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/acceptance/UserAcceptanceTest.java
@@ -40,15 +40,15 @@ public class UserAcceptanceTest extends AcceptanceTest {
     }
 
     public ExtractableResponse<Response> 내_회원_정보_조회_요청(TokenResponse tokenResponse) {
-        return given().log().all().
-                auth().oauth2(tokenResponse.getAccessToken()).
-                accept(MediaType.APPLICATION_JSON_VALUE).
-                when().
-                get("/members/me").
-                then().
-                log().all().
-                statusCode(HttpStatus.OK.value()).
-                extract();
+        return given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/members/me")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
     }
 
     public void 알맞은_회원_정보_조회됨(ExtractableResponse<Response> response, User expectedUser) {
@@ -60,14 +60,14 @@ public class UserAcceptanceTest extends AcceptanceTest {
     }
 
     public ExtractableResponse<Response> 토큰_없이_회원_정보_요청() {
-        return given().log().all().
-                accept(MediaType.APPLICATION_JSON_VALUE).
-                when().
-                get("/members/me").
-                then().
-                log().all().
-                statusCode(HttpStatus.UNAUTHORIZED.value()).
-                extract();
+        return given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/members/me")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .extract();
     }
 
     public void 토큰_필요_예외_발생(ExtractableResponse<Response> response) {

--- a/backend/src/test/java/com/wooteco/nolto/acceptance/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/acceptance/UserAcceptanceTest.java
@@ -1,0 +1,78 @@
+package com.wooteco.nolto.acceptance;
+
+import com.wooteco.nolto.auth.ui.dto.TokenResponse;
+import com.wooteco.nolto.exception.dto.ExceptionResponse;
+import com.wooteco.nolto.user.domain.User;
+import com.wooteco.nolto.user.ui.dto.MemberResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("회원 관련 기능")
+public class UserAcceptanceTest extends AcceptanceTest {
+
+    @DisplayName("로그인 된 사용자라면 회원 정보를 받아올 수 있다.")
+    @Test
+    void getMemberInfoWithToken() {
+        //given
+        TokenResponse userToken = 가입된_유저의_토큰을_받는다();
+
+        //when
+        ExtractableResponse<Response> response = 내_회원_정보_조회_요청(userToken);
+
+        //then
+        알맞은_회원_정보_조회됨(response, 엄청난_유저);
+    }
+
+    @DisplayName("로그인 되지 않은 사용자라면 회원 정보를 받아올 수 없다.")
+    @Test
+    void cannotGetMemberInfoWithoutToken() {
+        //when
+        ExtractableResponse<Response> response = 토큰_없이_회원_정보_요청();
+
+        //then
+        토큰_필요_예외_발생(response);
+    }
+
+    public ExtractableResponse<Response> 내_회원_정보_조회_요청(TokenResponse tokenResponse) {
+        return given().log().all().
+                auth().oauth2(tokenResponse.getAccessToken()).
+                accept(MediaType.APPLICATION_JSON_VALUE).
+                when().
+                get("/members/me").
+                then().
+                log().all().
+                statusCode(HttpStatus.OK.value()).
+                extract();
+    }
+
+    public void 알맞은_회원_정보_조회됨(ExtractableResponse<Response> response, User expectedUser) {
+        MemberResponse memberResponse = response.as(MemberResponse.class);
+        assertThat(memberResponse.getId()).isNotNull();
+        assertThat(memberResponse.getSocialType()).isEqualTo(expectedUser.getSocialType().name());
+        assertThat(memberResponse.getNickName()).isEqualTo(expectedUser.getNickName());
+        assertThat(memberResponse.getImageUrl()).isEqualTo(expectedUser.getImageUrl());
+    }
+
+    public ExtractableResponse<Response> 토큰_없이_회원_정보_요청() {
+        return given().log().all().
+                accept(MediaType.APPLICATION_JSON_VALUE).
+                when().
+                get("/members/me").
+                then().
+                log().all().
+                statusCode(HttpStatus.UNAUTHORIZED.value()).
+                extract();
+    }
+
+    public void 토큰_필요_예외_발생(ExtractableResponse<Response> response) {
+        ExceptionResponse exceptionResponse = response.as(ExceptionResponse.class);
+        assertThat(exceptionResponse.getErrorCode()).isEqualTo("auth-002");
+        assertThat(exceptionResponse.getMessage()).isEqualTo("토큰이 필요합니다.");
+    }
+}


### PR DESCRIPTION
## 작업 내용
- `GET: /members/me` 에 대한 인수테스트를 작성했습니다. 
    - 토큰이 있는 경우, `MemberResponse`가 정상 반환됩니다.
    - 토큰이 없는 경우, `ExceptionResponse`가 반환됩니다. 

## 주의사항
- 기존의 `AcceptanceTest`에서 `엄청난_유저`를 public 인스턴스 변수로 분리했습니다. 
    - 정상 반환 받은 `MemberResponse`의 내용이 `엄청난_유저`의 내용과 동일함을 판단하기 위함