### PR TITLE
fix: 피드 수정 시 태그 추가 버그 

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -76,6 +76,8 @@ public class FeedService {
         updateThumbnailIfImageExist(request, findFeed);
 
         feedTechRepository.deleteAll(findFeed.getFeedTechs());
+        findFeed.deleteFeedTechs();
+
         List<FeedTech> feedTechs = makeTechIdToFeedTech(request, findFeed);
         findFeed.changeFeedTechs(feedTechs);
     }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
@@ -143,6 +143,10 @@ public class Feed extends BaseEntity {
         this.likes.remove(like);
     }
 
+    public void deleteFeedTechs() {
+        this.feedTechs.clear();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
@@ -136,6 +136,35 @@ class FeedServiceTest {
         피드_정보가_같은지_조회(request, updateFeed);
     }
 
+    @DisplayName("Feed를 수정한다2. (storageUrl, deployUrl, thumbnailUrl을 제외한 나머지만 수정)")
+    @Test
+    void updateNewTechs2() {
+        // given
+        FEED_REQUEST2.setTechs(Arrays.asList(techSpring.getId(), techJava.getId()));
+        Long feedId1 = feedService.create(user1, FEED_REQUEST2); // 피드 등록 with Spring, Java
+        FeedRequest request = new FeedRequest(
+                "수정된 제목",
+                Arrays.asList(techJava.getId(), techReact.getId()),
+                "수정된 내용",
+                Step.COMPLETE.name(),
+                false,
+                FEED_REQUEST1.getStorageUrl(),
+                FEED_REQUEST1.getDeployedUrl(),
+                null
+        );
+        FeedResponse saveFeed = feedService.findById(user1, feedId1); // 피드 등록한거 조회
+
+        // when
+        feedService.update(user1, feedId1, request);
+        em.flush();
+        em.clear();
+
+        // then
+        FeedResponse updateFeed = feedService.findById(user1, feedId1);
+        System.out.println(" *************** " + updateFeed.getTechs().stream().count());
+        피드_정보가_같은지_조회(request, updateFeed);
+    }
+
     @DisplayName("작성자가 아닐 경우 Feed를 수정할 수 없다.")
     @Test
     void cantUpdateIfNotAuthor() {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nolto",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "repository": "https://github.com/woowacourse-teams/2021-nolto",
   "author": "zig & mickey",
   "license": "MIT",


### PR DESCRIPTION
## 작업 내용

- 피드 수정 시 태그가 삭제되지 않는 버그 수정

