### PR TITLE
refactor: 이미지 관련 요청 10MB 까지 허용하도록 수정

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     multipart:
       enabled: true
       file-size-threshold: 2MB
-      max-file-size: 5MB
+      max-file-size: 10MB
       max-request-size: 10MB
   jpa:
     hibernate:


### PR DESCRIPTION
## 작업 내용
- refactor: 이미지 관련 요청 10MB 까지 허용하도록 수정
- nginx 웹 서버와 요청 사이즈 동일하게 하기 위함