### PR TITLE
fix(GithubUserResponse): 깃허브 가입 시 닉네임이 없으면 생기는 버그 수정

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/auth/infrastructure/oauth/dto/GithubUserResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/infrastructure/oauth/dto/GithubUserResponse.java
@@ -13,10 +13,10 @@ import lombok.Setter;
 @AllArgsConstructor
 public class GithubUserResponse implements OAuthUserResponse {
     private Long id;
-    private String name;
+    private String login;
     private String avatar_url;
 
     public User toUser() {
-        return new User(String.valueOf(id), SocialType.GITHUB, name, avatar_url);
+        return new User(String.valueOf(id), SocialType.GITHUB, login, avatar_url);
     }
 }


### PR DESCRIPTION
## 작업 내용
- github: name이 없는 사용자가 있어 login으로 변경

Closes #283
