### PR TITLE
[FE] 피드 컨텐츠 관련 CSS 수정

### DIFF
--- a/frontend/src/components/FeedDetailContent/FeedDetailContent.styles.ts
+++ b/frontend/src/components/FeedDetailContent/FeedDetailContent.styles.ts
@@ -54,6 +54,7 @@ const Thumbnail = styled.div`
 
   & > img {
     position: absolute;
+    object-fit: contain;
     height: 100%;
     width: 100%;
     left: 0;

--- a/frontend/src/components/FeedDetailContent/FeedDetailContent.tsx
+++ b/frontend/src/components/FeedDetailContent/FeedDetailContent.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import Styled, { Tag, StacksMoreButton } from './FeedDetailContent.styles';
 import useFeedDetail from 'hooks/queries/useFeedDetail';
 import ViewCountIcon from 'assets/viewCount.svg';
 import Chip from 'components/@common/Chip/Chip';
@@ -11,6 +10,7 @@ import { PALETTE } from 'constants/palette';
 import { ButtonStyle } from 'types';
 import useSnackBar from 'context/snackBar/useSnackBar';
 import useMember from 'hooks/queries/useMember';
+import Styled, { Tag, StacksMoreButton } from './FeedDetailContent.styles';
 
 interface Props {
   id: number;

--- a/frontend/src/components/RegularCard/RegularCard.styles.ts
+++ b/frontend/src/components/RegularCard/RegularCard.styles.ts
@@ -10,6 +10,7 @@ const Root = styled(Card)<{ imageUrl: string }>`
   background-image: url(${({ imageUrl }) => imageUrl});
   background-size: cover;
   cursor: pointer;
+  overflow: hidden;
 
   &:hover::after {
     content: '';

--- a/frontend/src/components/StretchCard/StretchCard.styles.ts
+++ b/frontend/src/components/StretchCard/StretchCard.styles.ts
@@ -5,9 +5,9 @@ import { PALETTE } from 'constants/palette';
 
 const Root = styled(Card)`
   position: relative;
-  width: 34rem;
-  height: 6rem;
-  padding: 0.75rem 1rem;
+  width: 40rem;
+  height: 8rem;
+  padding: 0.5rem 1.25rem;
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -28,8 +28,8 @@ const Root = styled(Card)`
 `;
 
 const Thumbnail = styled.img`
-  width: 4.25rem;
-  height: 4.25rem;
+  width: 5.5rem;
+  height: 5.5rem;
   border-radius: 0.5rem;
 `;
 


### PR DESCRIPTION

## 작업 내용
- recent feed card 크기 키우기
- 피드 상세 페이지 사진 비율 조정
- hot feeds hover 시 레이아웃 깨지는 문제 수정

## 스크린샷
![image](https://user-images.githubusercontent.com/44080404/127649602-f7ac7588-b176-4006-a343-fb31e162aae5.png)
![image](https://user-images.githubusercontent.com/44080404/127649638-5b3f3fb9-39c8-4527-a65e-29e765e88547.png)
![image](https://user-images.githubusercontent.com/44080404/127649653-70c716de-3db0-4042-b020-5ef551d1f1a7.png)

