### PR TITLE
[FE] fix: Home의 trends 태그 underline 버그 수정

### DIFF
--- a/frontend/src/pages/Home/Home.styles.ts
+++ b/frontend/src/pages/Home/Home.styles.ts
@@ -63,12 +63,13 @@ const TrendContainer = styled.div`
 const TrendTag = styled.span`
   cursor: pointer;
 
-  &:hover {
-    text-decoration: underline;
+  > .trends-text {
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
-  &:before {
-    content: '|';
+  > .trends-bar {
     margin-right: 0.75rem;
   }
 `;

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -71,7 +71,8 @@ const Home = () => {
             <span className="trends">💎 Trends</span>
             {tags.map((tag) => (
               <Styled.TrendTag key={tag.id} onClick={() => searchByTrend(tag)}>
-                {tag.text}
+                <span className="trends-bar">|</span>
+                <span className="trends-text">{tag.text}</span>
               </Styled.TrendTag>
             ))}
           </Styled.TrendContainer>


### PR DESCRIPTION
## 작업 내용
Home의 trends 태그 hover 시 bar에도 underline이 생기는 버그 수정

Closes #307

## 스크린샷
![image](https://user-images.githubusercontent.com/44080404/127731387-8c12b6c6-2909-42f6-b80b-0b59e05cdb00.png)

