### PR TITLE
[FE] refactor: 피드 수정 페이지 디테일 변경

### DIFF
--- a/frontend/src/components/FeedUploadForm/FeedUploadForm.tsx
+++ b/frontend/src/components/FeedUploadForm/FeedUploadForm.tsx
@@ -212,7 +212,9 @@ const FeedUploadForm = ({ onFeedSubmit, initialFormValue }: Props) => {
       </Styled.StretchWrapper>
 
       <Styled.ButtonsWrapper>
-        <StyledButton buttonStyle={ButtonStyle.SOLID}>등록</StyledButton>
+        <StyledButton buttonStyle={ButtonStyle.SOLID}>
+          {initialFormValue ? '수정' : '등록'}
+        </StyledButton>
         <StyledButton onClick={handleCancelUpload} type="button" buttonStyle={ButtonStyle.OUTLINE}>
           취소
         </StyledButton>

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -7,8 +7,8 @@ export const UPLOAD_VALIDATION_MSG = {
 };
 
 export const ALERT_MSG = {
-  SUCCESS_UPLOAD_FEED: '🎉 토이 프로젝트 등록에 성공했습니다!',
-  SUCCESS_MODIFY_FEED: '🔧 토이 프로젝트 수정에 성공했습니다!',
+  SUCCESS_UPLOAD_FEED: '토이 프로젝트를 등록했습니다.',
+  SUCCESS_MODIFY_FEED: '토이 프로젝트를 수정했습니다.',
 };
 
 export const CONFIRM_MSG = {

--- a/frontend/src/context/techTag/chip/TechChips.tsx
+++ b/frontend/src/context/techTag/chip/TechChips.tsx
@@ -20,6 +20,7 @@ const TechChips = ({ className, reverse = false }: Props) => {
     <Styled.Root className={className}>
       {techTag.techs.map((tech) => (
         <TechButton
+          type="button"
           buttonStyle={ButtonStyle.SOLID}
           key={tech.id}
           reverse={reverse}

--- a/frontend/src/pages/Modify/Modify.tsx
+++ b/frontend/src/pages/Modify/Modify.tsx
@@ -7,14 +7,19 @@ import Header from 'components/Header/Header';
 import ROUTE from 'constants/routes';
 import { ALERT_MSG } from 'constants/message';
 import useNotification from 'context/notification/useNotification';
+import useSnackBar from 'context/snackBar/useSnackBar';
 import useFeedModify from 'hooks/mutations/useFeedModify';
 import Styled from './Modify.styles';
 import { FeedDetail } from 'types';
 
 const Modify = () => {
   const location = useLocation<{ feedDetail: FeedDetail }>();
-  const notification = useNotification();
   const history = useHistory();
+
+  const notification = useNotification();
+  const snackbar = useSnackBar();
+
+  const modifyMutation = useFeedModify();
 
   if (location.state?.feedDetail === undefined) {
     notification.alert('잘못된 접근입니다.');
@@ -34,15 +39,14 @@ const Modify = () => {
     storageUrl,
   } = location.state.feedDetail;
 
-  const modifyMutation = useFeedModify();
-
   const modifyFeed = (formData: FormData) => {
     modifyMutation.mutate(
       { feedId, formData },
       {
         onSuccess: () => {
-          notification.alert(ALERT_MSG.SUCCESS_MODIFY_FEED);
-          history.push(ROUTE.HOME);
+          snackbar.addSnackBar('success', ALERT_MSG.SUCCESS_MODIFY_FEED);
+
+          history.push(`${ROUTE.FEEDS}/${feedId}`);
         },
       },
     );

--- a/frontend/src/pages/Upload/Upload.tsx
+++ b/frontend/src/pages/Upload/Upload.tsx
@@ -4,21 +4,21 @@ import { useHistory } from 'react-router-dom';
 import HighLightedText from 'components/@common/HighlightedText/HighlightedText';
 import FeedUploadForm from 'components/FeedUploadForm/FeedUploadForm';
 import Header from 'components/Header/Header';
-import Styled from './Upload.styles';
 import useFeedUpload from 'hooks/mutations/useFeedUpload';
+import useSnackBar from 'context/snackBar/useSnackBar';
 import { ALERT_MSG } from 'constants/message';
 import ROUTE from 'constants/routes';
-import useNotification from 'context/notification/useNotification';
+import Styled from './Upload.styles';
 
 const Upload = () => {
   const uploadMutation = useFeedUpload();
-  const notification = useNotification();
   const history = useHistory();
+  const snackbar = useSnackBar();
 
   const uploadFeed = (formData: FormData) => {
     uploadMutation.mutate(formData, {
       onSuccess: () => {
-        notification.alert(ALERT_MSG.SUCCESS_UPLOAD_FEED);
+        snackbar.addSnackBar('success', ALERT_MSG.SUCCESS_UPLOAD_FEED);
         history.push(ROUTE.HOME);
       },
     });


### PR DESCRIPTION

## 작업 내용
- TechChip type button으로 변경
- 피드 수정 페이지에서 '등록' 버튼을 '수정' 버튼으로 변경
- 피드 등록/수정 시 noti가 아닌 snackbar 띄우기
- 피드 수정 완료 시 해당 피드 상세 페이지로 리다이렉트


