### PR TITLE
[FE] refactor: 최신 피드 & 검색 결과 페이지에서 피드가 넘칠 때 arrow 버튼 추가

### DIFF
--- a/frontend/src/components/RecentFeedsContent/RecentFeedsContent.styles.ts
+++ b/frontend/src/components/RecentFeedsContent/RecentFeedsContent.styles.ts
@@ -1,15 +1,24 @@
 import styled from 'styled-components';
 
 import Avatar from 'components/@common/Avatar/Avatar';
+import DownPolygon from 'assets/downPolygon.svg';
+import { PALETTE } from 'constants/palette';
 
 const Root = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
-  width: fit-content;
 `;
 
-const CardsContainer = styled.ul`
+const CardsContainer = styled.div`
+  height: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+`;
+
+const ScrollableContainer = styled.ul`
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 2rem;
@@ -38,9 +47,39 @@ const LevelButtonsContainer = styled.div`
   margin-bottom: 3.5rem;
 `;
 
+const MoreButton = styled.button`
+  bottom: 0.25rem;
+  width: calc(100% - 0.5rem);
+  height: 1.25rem;
+  margin: 0 0.5rem;
+  border: none;
+  border-radius: 0.25rem;
+  background-color: ${PALETTE.WHITE_400};
+  filter: drop-shadow(0 0 0.25rem rgba(0, 0, 0, 0.25));
+  overflow: hidden;
+
+  &:hover::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0.1;
+    background-color: ${PALETTE.BLACK_400};
+  }
+`;
+
+export const MoreFeedsArrow = styled(DownPolygon)`
+  fill: ${PALETTE.PRIMARY_400};
+`;
+
 export default {
   Root,
   CardsContainer,
+  ScrollableContainer,
   VerticalAvatar,
   LevelButtonsContainer,
+  MoreButton,
 };

--- a/frontend/src/components/RecentFeedsContent/RecentFeedsContent.tsx
+++ b/frontend/src/components/RecentFeedsContent/RecentFeedsContent.tsx
@@ -6,14 +6,14 @@ import StretchCard from 'components/StretchCard/StretchCard';
 import useRecentFeeds from 'hooks/queries/useRecentFeeds';
 import useSnackBar from 'context/snackBar/useSnackBar';
 import ROUTE from 'constants/routes';
-import Styled from './RecentFeedsContent.styles';
+import Styled, { MoreFeedsArrow } from './RecentFeedsContent.styles';
 import { FilterType } from 'types';
 
 interface Props {
-  limit?: number;
+  feedsCountToShow?: number;
 }
 
-const RecentFeedsContent = ({ limit }: Props) => {
+const RecentFeedsContent = ({ feedsCountToShow }: Props) => {
   const [filter, setFilter] = useState<FilterType>();
 
   const snackbar = useSnackBar();
@@ -44,15 +44,22 @@ const RecentFeedsContent = ({ limit }: Props) => {
         />
       </Styled.LevelButtonsContainer>
       <Styled.CardsContainer>
-        {recentFeeds &&
-          recentFeeds.slice(0, limit).map((feed) => (
-            <li key={feed.id}>
-              <Link to={`${ROUTE.FEEDS}/${feed.id}`}>
-                <Styled.VerticalAvatar user={feed.author} />
-                <StretchCard feed={feed} />
-              </Link>
-            </li>
-          ))}
+        <Styled.ScrollableContainer>
+          {recentFeeds &&
+            recentFeeds.slice(0, feedsCountToShow).map((feed) => (
+              <li key={feed.id}>
+                <Link to={`${ROUTE.FEEDS}/${feed.id}`}>
+                  <Styled.VerticalAvatar user={feed.author} />
+                  <StretchCard feed={feed} />
+                </Link>
+              </li>
+            ))}
+        </Styled.ScrollableContainer>
+        {!feedsCountToShow && (
+          <Styled.MoreButton>
+            <MoreFeedsArrow width="14px" />
+          </Styled.MoreButton>
+        )}
       </Styled.CardsContainer>
     </Styled.Root>
   );

--- a/frontend/src/components/SearchResultContent/SearchResultContent.styles.ts
+++ b/frontend/src/components/SearchResultContent/SearchResultContent.styles.ts
@@ -1,8 +1,16 @@
 import styled from 'styled-components';
 
 import Avatar from 'components/@common/Avatar/Avatar';
+import { PALETTE } from 'constants/palette';
+import DownPolygon from 'assets/downPolygon.svg';
 
-const Root = styled.ul`
+const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
+
+const ScrollableContainer = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 2rem;
@@ -24,7 +32,38 @@ const VerticalAvatar = styled(Avatar)`
   margin-bottom: 12px;
 `;
 
+const MoreButton = styled.button`
+  bottom: 0.25rem;
+  width: calc(100% - 0.5rem);
+  height: 1.25rem;
+  margin: 0 0.5rem;
+  border: none;
+  border-radius: 0.25rem;
+  background-color: ${PALETTE.WHITE_400};
+  filter: drop-shadow(0 0 0.25rem rgba(0, 0, 0, 0.25));
+  overflow: hidden;
+
+  &:hover::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0.1;
+    background-color: ${PALETTE.BLACK_400};
+  }
+`;
+
+export const MoreFeedsArrow = styled(DownPolygon)`
+  fill: ${PALETTE.PRIMARY_400};
+`;
+
 export default {
   Root,
+  ScrollableContainer,
   VerticalAvatar,
+  MoreButton,
+  MoreFeedsArrow,
 };

--- a/frontend/src/components/SearchResultContent/SearchResultContent.tsx
+++ b/frontend/src/components/SearchResultContent/SearchResultContent.tsx
@@ -5,7 +5,7 @@ import StretchCard from 'components/StretchCard/StretchCard';
 import ROUTE from 'constants/routes';
 import useSnackBar from 'context/snackBar/useSnackBar';
 import useSearch from 'hooks/queries/useSearch';
-import Styled from './SearchResultContent.styles';
+import Styled, { MoreFeedsArrow } from './SearchResultContent.styles';
 import { FilterType } from 'types';
 
 interface Props {
@@ -23,16 +23,26 @@ const SearchResultContent = (searchParams: Props) => {
     suspense: false,
   });
 
+  const isOverflown = feeds?.length >= 3;
+
   return (
     <Styled.Root>
-      {feeds?.map((feed) => (
-        <li key={feed.id}>
-          <Link to={`${ROUTE.FEEDS}/${feed.id}`}>
-            <Styled.VerticalAvatar user={feed.author} />
-            <StretchCard feed={feed} />
-          </Link>
-        </li>
-      ))}
+      <Styled.ScrollableContainer>
+        {feeds?.map((feed) => (
+          <li key={feed.id}>
+            <Link to={`${ROUTE.FEEDS}/${feed.id}`}>
+              <Styled.VerticalAvatar user={feed.author} />
+              <StretchCard feed={feed} />
+            </Link>
+          </li>
+        ))}
+      </Styled.ScrollableContainer>
+
+      {isOverflown && (
+        <Styled.MoreButton>
+          <MoreFeedsArrow width="14px" />
+        </Styled.MoreButton>
+      )}
     </Styled.Root>
   );
 };

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -93,7 +93,7 @@ const Home = () => {
             <AsyncBoundary
               rejectedFallback={<ErrorFallback message="데이터를 불러올 수 없습니다." />}
             >
-              <RecentFeedsContent limit={RECENT_FEED_LENGTH} />
+              <RecentFeedsContent feedsCountToShow={RECENT_FEED_LENGTH} />
             </AsyncBoundary>
             <MoreButton to={ROUTE.RECENT}>
               MORE&nbsp;

--- a/frontend/src/pages/RecentFeeds/RecentFeeds.styles.ts
+++ b/frontend/src/pages/RecentFeeds/RecentFeeds.styles.ts
@@ -14,7 +14,7 @@ const SectionTitle = styled(HighLightedText)`
 `;
 
 const RecentToysContainer = styled.div`
-  height: 45rem;
+  height: 56vh;
 `;
 
 export default {

--- a/frontend/src/pages/SearchResult/SearchResult.styles.ts
+++ b/frontend/src/pages/SearchResult/SearchResult.styles.ts
@@ -22,7 +22,7 @@ const LevelButtonsContainer = styled.div`
 `;
 
 const RecentToysContainer = styled.div`
-  height: 30rem;
+  height: 48vh;
 `;
 
 export const TechInput = styled(TechInputComponent)``;


### PR DESCRIPTION
## 작업 내용
최신 피드 & 검색 결과 페이지에서 피드가 넘칠 때 arrow 버튼 추가
너무 썰렁해서 스크롤을 할 수 있음을 표시하기 위해 추가해주었습니다

## 스크린샷
<img width="819" alt="스크린샷 2021-07-31 오후 6 05 31" src="https://user-images.githubusercontent.com/44080404/127734992-7f68207a-5d87-4d70-8bc7-c6c44d72d800.png">

## 주의사항
버튼 눌렀을 때 아직 아무 동작도 하지 않음. 이후 infinite scroll 등 구현 시 추가 예정 

## 주의사항
