### PR TITLE
refactor(logging): 에러 로그의 StackTrace를 하나의 출력으로 찍도록 수정

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/wooteco/nolto/exception/ControllerAdvice.java
@@ -33,12 +33,17 @@ public class ControllerAdvice {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleException(Exception e) {
         log.error("༼;´༎ຶ \u06DD ༎ຶ༽ \uD835\uDE52\uD835\uDE5D\uD835\uDE6E\uD835\uDE67\uD835\uDE56\uD835\uDE63\uD835\uDE64...");
-        log.error("Error Message : " + e.getMessage());
-        String stackTrace = Arrays.toString(e.getStackTrace());
-        String[] spiltMessages = stackTrace.split(",");
+        log.error("༼;´༎ຶ \u06DD ༎ຶ༽ 에러 로그 시작 ༼;´༎ຶ \u06DD ༎ຶ༽");
+        log.error("༼;´༎ຶ \u06DD ༎ຶ༽ 에러 메세지 : " + e.getMessage());
+        String[] spiltMessages = Arrays.toString(e.getStackTrace()).split(",");
+
+        StringBuilder sb = new StringBuilder();
         for (String splitMessage : spiltMessages) {
-            log.warn(splitMessage);
+            sb.append(splitMessage).append("\n");
         }
+        log.error(sb.toString());
+
+        log.error("༼;´༎ຶ \u06DD ༎ຶ༽ 에러 로그 끝 ༼;´༎ຶ \u06DD ༎ຶ༽");
         log.error("༼;´༎ຶ \u06DD ༎ຶ༽ \uD835\uDE52\uD835\uDE5D\uD835\uDE6E\uD835\uDE67\uD835\uDE56\uD835\uDE63\uD835\uDE64...");
         return ResponseEntity.internalServerError().body("놀토 관리자에게 문의하세요");
     }


### PR DESCRIPTION
## 작업 내용
- ControllerAdvice 에서 StackTrace 를 여러줄의 에러 로그로 출력하던 부분 수정
    + StringBuilder 를 사용해서 하나의 문자열로 만들어서 출력함

```java
        StringBuilder sb = new StringBuilder();
        for (String splitMessage : spiltMessages) {
            log.warn(splitMessage);
            sb.append(splitMessage).append("\n");
        }
        log.error(sb.toString());
```

Closes #316 

## 주의사항
슬랙 메세지 300개 무서워요