### PR TITLE
[FE] refactor: 검색옵션 열릴 때 부드러운 효과

### DIFF
--- a/frontend/src/components/SearchOption/SearchOption.styles.ts
+++ b/frontend/src/components/SearchOption/SearchOption.styles.ts
@@ -1,21 +1,35 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 import DownPolygon from 'assets/downPolygon.svg';
 import { PALETTE } from 'constants/palette';
 
+const opacityAnimation = keyframes`
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity : 1;
+  }
+`;
+
+const OPACITY_ANIMATION_TIME = '0.5s';
+
 const Root = styled.div<{ isOpen: boolean }>`
+  height: ${({ isOpen }) => (isOpen ? '7rem' : '2.5rem')};
   min-width: 108px;
   background-color: ${PALETTE.WHITE_400};
   align-self: flex-start;
   border-radius: 25px;
   filter: drop-shadow(0 0 4px rgba(0, 0, 0, 0.25));
+  transition: height 0.3s ease;
 `;
 
 const DefaultSelector = styled.span`
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.4rem;
   line-height: 1rem;
   cursor: pointer;
 `;
@@ -31,6 +45,8 @@ const SearchOptionText = styled.div`
   text-align: center;
   line-height: 1.15rem;
   margin: 0.65rem 0;
+
+  animation: ${opacityAnimation} ${OPACITY_ANIMATION_TIME} ease;
 
   &.option {
     &:hover {

--- a/frontend/src/components/SearchOption/SearchOption.tsx
+++ b/frontend/src/components/SearchOption/SearchOption.tsx
@@ -21,7 +21,7 @@ const SearchOption = ({ searchType, setSearchType }: Props) => {
     <Styled.Root isOpen={isOptionOpened}>
       <Styled.DefaultSelector onClick={() => setIsOptionOpened(!isOptionOpened)}>
         <Styled.SearchOptionText>{searchType}</Styled.SearchOptionText>
-        <SearchMorePolygon width="14px" fill={PALETTE.PRIMARY_400} isOpen={isOptionOpened} />
+        <SearchMorePolygon width="12px" fill={PALETTE.PRIMARY_400} isOpen={isOptionOpened} />
       </Styled.DefaultSelector>
       {isOptionOpened && (
         <>


### PR DESCRIPTION
## 작업 내용
refactor: 검색옵션 열릴 때 부드러운 효과

## 스크린샷
![search-option](https://media.giphy.com/media/t9cjtR7rEeRwwM45Ky/giphy.gif)

## 주의사항
`height: auto`면 transition이 동작하지 않음.
임의로 보기 좋은 px 단위로 height를 넣어서 transition을 만들었습니다 