### PR TITLE
feat: 유저 히스토리 조회 기능 구현

### DIFF
--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -13,3 +13,17 @@ include::{snippets}/member-findMe/http-response.adoc[]
 ==== Response Fields
 
 include::{snippets}/member-findMe/response-fields.adoc[]
+
+=== 멤버 자신의 히스토리(좋아요 한 글, 내가 작성한 글, 내가 남긴 댓글) 조회
+
+==== Request
+
+include::{snippets}/member-findHistory/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/member-findHistory/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/member-findHistory/response-fields.adoc[]

--- a/backend/src/main/java/com/wooteco/nolto/user/application/UserService.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/application/UserService.java
@@ -1,13 +1,24 @@
 package com.wooteco.nolto.user.application;
 
+import com.wooteco.nolto.feed.domain.Comment;
+import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
+import com.wooteco.nolto.user.ui.dto.MemberHistoryResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @AllArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
 
-
+    public MemberHistoryResponse findHistory(User user) {
+        List<Feed> likedFeeds = user.findLikedFeeds();
+        List<Feed> myFeeds = user.getFeeds();
+        List<Comment> myComments = user.getComments();
+        return MemberHistoryResponse.of(likedFeeds, myFeeds, myComments);
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -15,6 +15,7 @@ import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -93,6 +94,12 @@ public class User {
         return this.feeds.stream()
                 .filter(feed -> feedId.equals(feed.getId()))
                 .findAny().orElseThrow(() -> new UnauthorizedException(ErrorType.UNAUTHORIZED_UPDATE_FEED));
+    }
+
+    public List<Feed> findLikedFeeds() {
+        return this.likes.stream()
+                .map(Like::getFeed)
+                .collect(Collectors.toList());
     }
 
     private static class GuestUser extends User {

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/UserController.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/UserController.java
@@ -2,7 +2,9 @@ package com.wooteco.nolto.user.ui;
 
 import com.wooteco.nolto.auth.MemberAuthenticationPrincipal;
 import com.wooteco.nolto.auth.ValidTokenRequired;
+import com.wooteco.nolto.user.application.UserService;
 import com.wooteco.nolto.user.domain.User;
+import com.wooteco.nolto.user.ui.dto.MemberHistoryResponse;
 import com.wooteco.nolto.user.ui.dto.MemberResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,9 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
 @AllArgsConstructor
 public class UserController {
 
+    private final UserService userService;
+
     @ValidTokenRequired
     @GetMapping("/me")
     public ResponseEntity<MemberResponse> findMemberOfMine(@MemberAuthenticationPrincipal User user) {
         return ResponseEntity.ok(MemberResponse.of(user));
+    }
+
+    @ValidTokenRequired
+    @GetMapping("/me/history")
+    public ResponseEntity<MemberHistoryResponse> findHistory(@MemberAuthenticationPrincipal User user) {
+        MemberHistoryResponse memberHistoryResponse = userService.findHistory(user);
+        return ResponseEntity.ok(memberHistoryResponse);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/CommentHistoryResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/CommentHistoryResponse.java
@@ -1,0 +1,25 @@
+package com.wooteco.nolto.user.ui.dto;
+
+import com.wooteco.nolto.feed.domain.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class CommentHistoryResponse {
+    private final FeedHistoryResponse feed;
+    private final String text;
+
+    public static CommentHistoryResponse of(Comment comment) {
+        return new CommentHistoryResponse(FeedHistoryResponse.of(comment.getFeed()), comment.getContent());
+    }
+
+    public static List<CommentHistoryResponse> toList(List<Comment> comments) {
+        return comments.stream()
+                .map(CommentHistoryResponse::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/FeedHistoryResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/FeedHistoryResponse.java
@@ -1,0 +1,35 @@
+package com.wooteco.nolto.user.ui.dto;
+
+import com.wooteco.nolto.feed.domain.Feed;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class FeedHistoryResponse {
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final String step;
+    private final boolean sos;
+    private final String thumbnailUrl;
+
+    public static FeedHistoryResponse of(Feed feed) {
+        return new FeedHistoryResponse(
+                feed.getId(),
+                feed.getTitle(),
+                feed.getContent(),
+                feed.getStep().name(),
+                feed.isSos(),
+                feed.getThumbnailUrl());
+    }
+
+    public static List<FeedHistoryResponse> toList(List<Feed> feeds) {
+        return feeds.stream()
+                .map(FeedHistoryResponse::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/MemberHistoryResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/MemberHistoryResponse.java
@@ -1,0 +1,24 @@
+package com.wooteco.nolto.user.ui.dto;
+
+import com.wooteco.nolto.feed.domain.Comment;
+import com.wooteco.nolto.feed.domain.Feed;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MemberHistoryResponse {
+    private final List<FeedHistoryResponse> likedFeeds;
+    private final List<FeedHistoryResponse> myFeeds;
+    private final List<CommentHistoryResponse> myComments;
+
+    public static MemberHistoryResponse of(List<Feed> likedFeeds, List<Feed> myFeeds, List<Comment> myComments) {
+        return new MemberHistoryResponse(
+                FeedHistoryResponse.toList(likedFeeds),
+                FeedHistoryResponse.toList(myFeeds),
+                CommentHistoryResponse.toList(myComments)
+        );
+    }
+}

--- a/backend/src/test/java/com/wooteco/nolto/acceptance/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/acceptance/UserAcceptanceTest.java
@@ -3,6 +3,7 @@ package com.wooteco.nolto.acceptance;
 import com.wooteco.nolto.auth.ui.dto.TokenResponse;
 import com.wooteco.nolto.exception.dto.ExceptionResponse;
 import com.wooteco.nolto.user.domain.User;
+import com.wooteco.nolto.user.ui.dto.MemberHistoryResponse;
 import com.wooteco.nolto.user.ui.dto.MemberResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
+import static com.wooteco.nolto.acceptance.FeedAcceptanceTest.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("회원 관련 기능")
@@ -38,7 +40,30 @@ public class UserAcceptanceTest extends AcceptanceTest {
         //then
         토큰_필요_예외_발생(response);
     }
+/*
+    @DisplayName("사용자의 히스토리(좋아요 한 글, 내가 작성한 글, 내가 남긴 댓글)를 조회할 수 있다.")
+    @Test
+    void getUserHistory() {
+        //given
+        TokenResponse userToken1 = 가입된_유저의_토큰을_받는다();
+        TokenResponse userToken2 = 가입된_유저의_토큰을_받는다(엄청난_유저2);
 
+        ExtractableResponse<Response> saveResponse1 = 피드를_작성한다(진행중_단계의_피드_요청, userToken1.getAccessToken());
+        Long feedId1 = Long.valueOf(saveResponse1.header("Location").replace("/feeds/", ""));
+
+        ExtractableResponse<Response> saveResponse2 = 피드를_작성한다(전시중_단계의_피드_요청, userToken2.getAccessToken());
+        Long feedId2 = Long.valueOf(saveResponse2.header("Location").replace("/feeds/", ""));
+
+        좋아요를_누른다(userToken1.getAccessToken(), feedId1);
+        좋아요를_누른다(userToken1.getAccessToken(), feedId2);
+
+        //when
+        ExtractableResponse<Response> response = 내_히스토리_조회_요청(userToken1);
+
+        //then
+        알맞은_회원_히스토리_조회됨(response, 엄청난_유저);
+    }
+*/
     public ExtractableResponse<Response> 내_회원_정보_조회_요청(TokenResponse tokenResponse) {
         return given().log().all()
                 .auth().oauth2(tokenResponse.getAccessToken())
@@ -74,5 +99,24 @@ public class UserAcceptanceTest extends AcceptanceTest {
         ExceptionResponse exceptionResponse = response.as(ExceptionResponse.class);
         assertThat(exceptionResponse.getErrorCode()).isEqualTo("auth-002");
         assertThat(exceptionResponse.getMessage()).isEqualTo("토큰이 필요합니다.");
+    }
+
+    private ExtractableResponse<Response> 내_히스토리_조회_요청(TokenResponse tokenResponse) {
+        return given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/members/me/history")
+                .then()
+                .log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+    }
+
+    private void 알맞은_회원_히스토리_조회됨(ExtractableResponse<Response> response, User expectedUser) {
+        MemberHistoryResponse memberHistoryResponse = response.as(MemberHistoryResponse.class);
+        assertThat(memberHistoryResponse.getLikedFeeds()).isNotNull();
+        assertThat(memberHistoryResponse.getMyFeeds()).isNotNull();
+        assertThat(memberHistoryResponse.getMyComments()).isNotNull();
     }
 }

--- a/backend/src/test/java/com/wooteco/nolto/acceptance/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/acceptance/UserAcceptanceTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import static com.wooteco.nolto.acceptance.FeedAcceptanceTest.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("회원 관련 기능")
@@ -40,30 +39,7 @@ public class UserAcceptanceTest extends AcceptanceTest {
         //then
         토큰_필요_예외_발생(response);
     }
-/*
-    @DisplayName("사용자의 히스토리(좋아요 한 글, 내가 작성한 글, 내가 남긴 댓글)를 조회할 수 있다.")
-    @Test
-    void getUserHistory() {
-        //given
-        TokenResponse userToken1 = 가입된_유저의_토큰을_받는다();
-        TokenResponse userToken2 = 가입된_유저의_토큰을_받는다(엄청난_유저2);
 
-        ExtractableResponse<Response> saveResponse1 = 피드를_작성한다(진행중_단계의_피드_요청, userToken1.getAccessToken());
-        Long feedId1 = Long.valueOf(saveResponse1.header("Location").replace("/feeds/", ""));
-
-        ExtractableResponse<Response> saveResponse2 = 피드를_작성한다(전시중_단계의_피드_요청, userToken2.getAccessToken());
-        Long feedId2 = Long.valueOf(saveResponse2.header("Location").replace("/feeds/", ""));
-
-        좋아요를_누른다(userToken1.getAccessToken(), feedId1);
-        좋아요를_누른다(userToken1.getAccessToken(), feedId2);
-
-        //when
-        ExtractableResponse<Response> response = 내_히스토리_조회_요청(userToken1);
-
-        //then
-        알맞은_회원_히스토리_조회됨(response, 엄청난_유저);
-    }
-*/
     public ExtractableResponse<Response> 내_회원_정보_조회_요청(TokenResponse tokenResponse) {
         return given().log().all()
                 .auth().oauth2(tokenResponse.getAccessToken())

--- a/backend/src/test/java/com/wooteco/nolto/api/FeedControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/FeedControllerTest.java
@@ -54,10 +54,10 @@ public class FeedControllerTest extends ControllerTest {
 
     private static final long FEED_ID = 1L;
 
-    private static final Feed FEED1 =
+    public static final Feed FEED1 =
             new Feed(1L, "title1", "content1", Step.PROGRESS, true, "www.surl.com", "www.durl.com", "www.turl.com").writtenBy(LOGIN_USER);
 
-    private static final Feed FEED2 =
+    public static final Feed FEED2 =
             new Feed(2L, "title2", "content2", Step.COMPLETE, false, "", "http://woowa.jofilm.com", "", 2, LOGIN_USER, new ArrayList<>());
 
     private static final List<FeedCardResponse> FEED_CARD_RESPONSES = FeedCardResponse.toList(Arrays.asList(FEED1, FEED2));

--- a/backend/src/test/java/com/wooteco/nolto/api/UserControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/UserControllerTest.java
@@ -1,15 +1,26 @@
 package com.wooteco.nolto.api;
 
 import com.wooteco.nolto.auth.domain.SocialType;
+import com.wooteco.nolto.feed.domain.Comment;
+import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.user.application.UserService;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.ui.UserController;
+import com.wooteco.nolto.user.ui.dto.MemberHistoryResponse;
 import com.wooteco.nolto.user.ui.dto.MemberResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.util.Arrays;
+import java.util.List;
+
+import static com.wooteco.nolto.api.FeedControllerTest.FEED1;
+import static com.wooteco.nolto.api.FeedControllerTest.FEED2;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -22,7 +33,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class UserControllerTest extends ControllerTest {
     private static final User LOGIN_USER =
             new User(1L, "11111", SocialType.GOOGLE, "아마찌", "imageUrl");
+
     private static final MemberResponse MEMBER_RESPONSE = MemberResponse.of(LOGIN_USER);
+
+    private static final FieldDescriptor[] FEED_SIMPLE_RESPONSE = new FieldDescriptor[]{
+            fieldWithPath("id").type(JsonFieldType.NUMBER).description("피드 ID"),
+            fieldWithPath("title").type(JsonFieldType.STRING).description("피드 제목"),
+            fieldWithPath("content").type(JsonFieldType.STRING).description("피드 내용"),
+            fieldWithPath("step").type(JsonFieldType.STRING).description("프로젝트 단계"),
+            fieldWithPath("sos").type(JsonFieldType.BOOLEAN).description("SOS 여부"),
+            fieldWithPath("thumbnailUrl").type(JsonFieldType.STRING).description("썸네일 URL")
+    };
+
+    private static final FieldDescriptor[] COMMENT_RESPONSE = new FieldDescriptor[]{
+            fieldWithPath("text").type(JsonFieldType.STRING).description("댓글 내용")
+    };
+
+    @MockBean
+    public UserService userService;
+
+    private MemberHistoryResponse memberHistoryResponse;
 
     @DisplayName("멤버가 자신의 정보를 조회한다.")
     @Test
@@ -45,5 +75,44 @@ class UserControllerTest extends ControllerTest {
                                 fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("멤버 이미지 주소")
                         )
                 ));
+    }
+
+    @DisplayName("멤버가 자신의 히스토리(좋아요 한 글, 내가 작성한 글, 내가 남긴 댓글)를 조회한다.")
+    @Test
+    void findHistory() throws Exception {
+        given(authService.findUserByToken("accessToken")).willReturn(LOGIN_USER);
+        setMemberHistoryResponse();
+        given(userService.findHistory(LOGIN_USER)).willReturn(memberHistoryResponse);
+
+        mockMvc.perform(
+                get("/members/me/history")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer accessToken"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(memberHistoryResponse)))
+                .andDo(document("member-findHistory",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        responseFields(
+                                fieldWithPath("likedFeeds").type(JsonFieldType.ARRAY).description("좋아요 누른 피드"),
+                                fieldWithPath("myFeeds").type(JsonFieldType.ARRAY).description("내가 작성한 피드"),
+                                fieldWithPath("myComments").type(JsonFieldType.ARRAY).description("내가 작성한 댓글")
+                        ).andWithPrefix("likedFeeds.[].", FEED_SIMPLE_RESPONSE)
+                                .andWithPrefix("myFeeds.[].", FEED_SIMPLE_RESPONSE)
+                                .andWithPrefix("myComments.[].feed.", FEED_SIMPLE_RESPONSE)
+                                .andWithPrefix("myComments.[].", COMMENT_RESPONSE)
+                ));
+    }
+
+    void setMemberHistoryResponse() {
+        List<Feed> likedFeeds = Arrays.asList(FEED1, FEED2);
+        List<Feed> myFeeds = Arrays.asList(FEED1, FEED2);
+        Comment comment1 = new Comment("comment1", true).writtenBy(LOGIN_USER);
+        comment1.setFeed(FEED1);
+        Comment comment2 = new Comment("comment2", true).writtenBy(LOGIN_USER);
+        comment2.setFeed(FEED2);
+        List<Comment> myComments = Arrays.asList(comment1, comment2);
+
+        memberHistoryResponse = MemberHistoryResponse.of(likedFeeds, myFeeds, myComments);
     }
 }

--- a/backend/src/test/java/com/wooteco/nolto/user/application/UserServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/user/application/UserServiceTest.java
@@ -1,0 +1,94 @@
+package com.wooteco.nolto.user.application;
+
+import com.wooteco.nolto.auth.domain.SocialType;
+import com.wooteco.nolto.feed.domain.Comment;
+import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.feed.domain.Like;
+import com.wooteco.nolto.feed.domain.Step;
+import com.wooteco.nolto.user.domain.User;
+import com.wooteco.nolto.user.domain.UserRepository;
+import com.wooteco.nolto.user.ui.dto.CommentHistoryResponse;
+import com.wooteco.nolto.user.ui.dto.FeedHistoryResponse;
+import com.wooteco.nolto.user.ui.dto.MemberHistoryResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class UserServiceTest {
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private final User joel = new User(null, "1", SocialType.GITHUB, "JOEL", "joel.jpg");
+    private final User ama = new User(null, "2", SocialType.GITHUB, "AMAZZI", "ama.jpg");
+
+    private final Feed joelFeed = new Feed("joelFeed", "joelFeed", Step.PROGRESS, true, "", "", "").writtenBy(joel);
+    private final Feed amaFeed = new Feed("amaFeed", "amaFeed", Step.PROGRESS, true, "", "", "").writtenBy(ama);
+
+    private final Comment joelCommentsJoelFeed = new Comment("joelCommentJoelFeed", true).writtenBy(joel);
+    private final Comment joelCommentsAmaFeed = new Comment("joelCommentAmaFeed", true).writtenBy(joel);
+
+    private final Like joelLikesJoelFeed = new Like(joel, joelFeed);
+    private final Like joelLikesAmaFeed = new Like(joel, amaFeed);
+
+    @BeforeEach
+    void setUp() {
+        joelFeed.addComment(joelCommentsJoelFeed);
+        amaFeed.addComment(joelCommentsAmaFeed);
+        joel.addLike(joelLikesJoelFeed);
+        joel.addLike(joelLikesAmaFeed);
+        userRepository.save(ama);
+        userRepository.save(joel);
+
+        em.flush();
+        em.clear();
+    }
+
+    @DisplayName("사용자의 히스토리(좋아요 한 글, 내가 작성한 글, 내가 남긴 댓글)를 조회할 수 있다.")
+    @Test
+    void findHistory() {
+        //when
+        MemberHistoryResponse memberHistoryResponse = userService.findHistory(joel);
+
+        //then
+        List<String> likedFeedsTitle = getFeedHistoryResponseTitle(memberHistoryResponse.getLikedFeeds());
+        assertThat(likedFeedsTitle).containsExactly(joelFeed.getTitle(), amaFeed.getTitle());
+
+        List<String> myFeedsTitle = getFeedHistoryResponseTitle(memberHistoryResponse.getMyFeeds());
+        assertThat(myFeedsTitle).containsExactly(joelFeed.getTitle());
+
+        List<String> myComments = getCommentResponseComment(memberHistoryResponse.getMyComments());
+        assertThat(myComments).containsExactly(joelCommentsJoelFeed.getContent(), joelCommentsAmaFeed.getContent());
+    }
+
+    public List<String> getFeedHistoryResponseTitle(List<FeedHistoryResponse> feedHistoryResponses) {
+        return feedHistoryResponses.stream()
+                .map(FeedHistoryResponse::getTitle)
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getCommentResponseComment(List<CommentHistoryResponse> commentHistoryResponses) {
+        return commentHistoryResponses.stream()
+                .map(CommentHistoryResponse::getText)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 작업 내용
- **유저 히스토리(좋아요 한 글, 내가 작성한 글, 내가 남긴 댓글)를 조회하는 기능을 구현했어요**
    - ArgumentResolver에서 받은 User를 바로 Dto에 넘겨 처리할 수 있지만, 서비스단에서 로직을 구현했어요
        - 사실 그냥 Dto에서 정보만 추출해서 포장하면 처리할 수 있는 로직인 것은 맞아요
        - 하지만 히스토리 관련 정보들에 조건들이 걸리게 된다면(최근에 올린순으로 정렬 등) 서비스 레이어에서 코드를 수정하게 될 것이라 생각했어요
        - 추후 확장성 + 엔티티를 서비스에서 다루는 게 맞지 않나 라는 생각에 서비스레이어에서 처리했습니다
    - 아직 댓글 기능이 완전히 구현되지는 않아서 컨트롤러 테스트에서 모킹을 조금 더 쉽게 하고자함도 있었어요

- **컨트롤러/서비스 레이어에 대한 테스트 코드를 작성했어요**
    - [컨트롤러]
        - UserService를 모킹하여 정해진 MemberHistoryResponse를 반환하게 하였어요
        - member.adoc에 해당 스니펫 추가하여 문서화 진행했어요
    - [서비스]
        - User가 Cascade-All 임을 활용하여 테스트코드를 작성하였어요
            - User에 피드/댓글/좋아요 넣고 저장하면 피드/댓글/좋아요가 알아서 저장되어요
    - [인수테스트]
        - 아직 댓글을 작성하는 엔드포인트가 작성되지 않아 테스트 하기 힘들것이라 판별했어요
        - 추후 작성 예정입니다

Closes #342

## 주의사항
- 인수테스트에서 API에 대한 요청은 static으로 빼서 다른 인수테스트에서도 활용가능하게 하도록 리팩토링이 필요해 보여요. 
    - 제가 하려고 했는데 AcceptanceTest의 given() 이 static으로 전환되어야 해서 대대적인 공사가 필요해보여 논의 한 다음에 해야할 것 같더라고요!
- DTO에 `@Getter` 안써서 삽질했어요. 조심하세요