### PR TITLE
fix: 대댓글을 조회한다. 최신 순으로 대댓글이 나열 (아마찌 -> 포모 -> 조엘) 테스트 깨지는 것 수정

### DIFF
--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
@@ -226,7 +226,6 @@ class CommentServiceTest extends CommentServiceFixture {
         Comment 아마찌_대댓글 = 댓글_생성("내 글에서 광고하지마!!!", false, 아마찌, 아마찌의_개쩌는_지하철_미션);
         아마찌_대댓글.addParentComment(찰리_댓글);
         List<Comment> saveReplies = commentRepository.saveAllAndFlush(Arrays.asList(찰리_댓글, 조엘_대댓글, 포모_대댓글, 아마찌_대댓글));
-        entityManager.clear();
 
         // when
         List<ReplyResponse> findReplies = commentService.findAllRepliesById(찰리1, 아마찌의_개쩌는_지하철_미션.getId(), 찰리_댓글.getId());


### PR DESCRIPTION
## 작업 내용
- develop pull 받아서 돌려봤는데 제 컴퓨터에서 터지는 테스트가 하나 있었습니다. 
- 보니까 젠킨스에서도 같은 테스트가 터져서 저번에 빌드가 실패했더라고요
- entityManager.clear() 한 줄 제거하니까 테스트 코드 잘 돌아서 우선 PR 보냅니다


## 스크린샷
![image](https://user-images.githubusercontent.com/61370901/128437452-6549b689-2556-44fe-8745-5efb4062e207.png)
