### PR TITLE
[FE] Mypage의 Intro, Notification, History api 연동

### DIFF
--- a/frontend/src/__mocks__/fixture/User.ts
+++ b/frontend/src/__mocks__/fixture/User.ts
@@ -5,38 +5,38 @@ type UserName = 'MICKEY' | 'ZIG' | 'MAZZI' | 'JOEL' | 'CHARLIE' | 'POMO';
 export const MOCK_USER: Record<UserName, UserInfo> = {
   MICKEY: {
     id: 1,
-    socialType: 'GITHUB',
     nickname: '미키',
     imageUrl: 'https://avatars.githubusercontent.com/u/48755175?v=4',
+    notifications: 2,
   },
   ZIG: {
     id: 2,
-    socialType: 'GOOGLE',
     nickname: '지그',
     imageUrl: 'https://avatars.githubusercontent.com/u/44080404?v=4',
+    notifications: 3,
   },
   MAZZI: {
     id: 3,
-    socialType: 'GITHUB',
     nickname: '마찌',
     imageUrl: 'https://avatars.githubusercontent.com/u/43840561?v=4',
+    notifications: 4,
   },
   JOEL: {
     id: 4,
-    socialType: 'GOOGLE',
     nickname: '조엘',
     imageUrl: 'https://avatars.githubusercontent.com/u/61370901?v=4',
+    notifications: 3,
   },
   CHARLIE: {
     id: 5,
-    socialType: 'GITHUB',
     nickname: '찰리',
     imageUrl: 'https://avatars.githubusercontent.com/u/57378410?v=4',
+    notifications: 3,
   },
   POMO: {
     id: 6,
-    socialType: 'GOOGLE',
     nickname: '포모',
     imageUrl: 'https://avatars.githubusercontent.com/u/34594339?v=4',
+    notifications: 0,
   },
 };

--- a/frontend/src/components/FeedUploadForm/FeedUploadForm.tsx
+++ b/frontend/src/components/FeedUploadForm/FeedUploadForm.tsx
@@ -10,6 +10,7 @@ import RadioButton from 'components/@common/RadioButton/RadioButton';
 import ErrorMessage from 'components/@common/ErrorMessage/ErrorMessage';
 import { FlexContainer } from 'commonStyles';
 import REGEX from 'constants/regex';
+import { THUMBNAIL_EXTENSION } from 'constants/common';
 import { CONFIRM_MSG, UPLOAD_VALIDATION_MSG } from 'constants/message';
 import TechInput from 'context/techTag/input/TechInput';
 import TechTagProvider from 'context/techTag/TechTagProvider';
@@ -33,17 +34,6 @@ interface Props {
   onFeedSubmit: (formData: FormData) => void;
   initialFormValue?: Omit<FeedToUpload, 'thumbnailImage'>;
 }
-
-const THUMBNAIL_EXTENSION = [
-  'image/apng',
-  'image/bmp',
-  'image/gif',
-  'image/jpg',
-  'image/jpeg',
-  'image/pjpeg',
-  'image/png',
-  'image/svg+xml',
-];
 
 const FeedUploadForm = ({ onFeedSubmit, initialFormValue }: Props) => {
   const {

--- a/frontend/src/components/UserProfile/UserProfile.styles.ts
+++ b/frontend/src/components/UserProfile/UserProfile.styles.ts
@@ -26,12 +26,28 @@ const UserThumbnail = styled.div`
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  position: relative;
   cursor: pointer;
 `;
 
+const NotiAlert = styled.div`
+  position: absolute;
+  top: -0.15rem;
+  left: -0.35rem;
+  width: 1.15rem;
+  height: 1.15rem;
+  color: ${PALETTE.WHITE_400};
+  font-size: 0.65rem;
+  line-height: 1.15rem;
+  text-align: center;
+  background-color: ${PALETTE.RED_400};
+  border: 1px solid ${PALETTE.PRIMARY_400};
+  border-radius: 50%;
+`;
+
 const Image = styled.img`
-  width: 2rem;
-  height: 2rem;
+  width: 2.5rem;
+  height: 2.5rem;
   border-radius: 50%;
 `;
 
@@ -46,6 +62,7 @@ const Dropdown = styled.div<{ isOpen: boolean }>`
   display: ${({ isOpen }) => (isOpen ? 'flex' : 'none')};
   position: absolute;
   width: fit-content;
+  max-width: 8rem;
   top: 120%;
   flex-direction: column;
   align-items: center;
@@ -80,8 +97,29 @@ const buttonStyle = css`
   ${hoverLayer({})};
 `;
 
-export const Link = styled(LinkElement)`
+export const ProfileLink = styled(LinkElement)`
   ${buttonStyle};
+`;
+
+export const NotiLink = styled(LinkElement)`
+  ${buttonStyle};
+
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+
+  & .noti-count {
+    display: inline-block;
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    padding: 0;
+    background-color: ${PALETTE.RED_400};
+    color: ${PALETTE.WHITE_400};
+    font-size: 0.75rem;
+    line-height: 1.25rem;
+    text-align: center;
+  }
 `;
 
 const Button = styled.button`
@@ -91,6 +129,7 @@ const Button = styled.button`
 export default {
   Root,
   UserThumbnail,
+  NotiAlert,
   Image,
   MoreProfileButton,
   Dropdown,

--- a/frontend/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/src/components/UserProfile/UserProfile.tsx
@@ -5,7 +5,7 @@ import useDialog from 'context/dialog/useDialog';
 import { PALETTE } from 'constants/palette';
 import ROUTE from 'constants/routes';
 import useMember from 'hooks/queries/useMember';
-import Styled, { Link } from './UserProfile.styles';
+import Styled, { NotiLink, ProfileLink } from './UserProfile.styles';
 
 interface Props {
   className?: string;
@@ -22,6 +22,8 @@ const UserProfile = ({ className }: Props) => {
     dialog.alert('로그아웃되었습니다.');
   };
 
+  const notiCount = member.userData?.notifications;
+
   return (
     <Styled.Root className={className} onClick={() => setIsProfileOpen(!isProfileOpen)}>
       <Styled.UserThumbnail>
@@ -29,10 +31,14 @@ const UserProfile = ({ className }: Props) => {
         <Styled.MoreProfileButton>
           <DownPolygon width="14px" fill={PALETTE.WHITE_400} />
         </Styled.MoreProfileButton>
+        {notiCount > 0 && <Styled.NotiAlert>{notiCount}</Styled.NotiAlert>}
       </Styled.UserThumbnail>
       <Styled.Dropdown isOpen={isProfileOpen}>
         <Styled.Greeting>👋 Hello, {member.userData?.nickname}!</Styled.Greeting>
-        <Link to={ROUTE.MYPAGE}>Profile</Link>
+        <NotiLink to={ROUTE.MYPAGE}>
+          새 알림 {notiCount > 0 && <span className="noti-count">{notiCount}</span>}
+        </NotiLink>
+        <ProfileLink to={ROUTE.MYPAGE}>Profile</ProfileLink>
         <Styled.Button onClick={logout}>Logout</Styled.Button>
       </Styled.Dropdown>
     </Styled.Root>

--- a/frontend/src/constants/common.ts
+++ b/frontend/src/constants/common.ts
@@ -4,3 +4,14 @@ export const STEP_CONVERTER: { [index: string]: string } = {
   [FeedStatus.PROGRESS]: '조립중',
   [FeedStatus.COMPLETE]: '전시중',
 };
+
+export const THUMBNAIL_EXTENSION = [
+  'image/apng',
+  'image/bmp',
+  'image/gif',
+  'image/jpg',
+  'image/jpeg',
+  'image/pjpeg',
+  'image/png',
+  'image/svg+xml',
+];

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -9,6 +9,8 @@ export const UPLOAD_VALIDATION_MSG = {
 export const ALERT_MSG = {
   SUCCESS_UPLOAD_FEED: '토이 프로젝트를 등록했습니다.',
   SUCCESS_MODIFY_FEED: '토이 프로젝트를 수정했습니다.',
+  SUCCESS_EDIT_PROFILE: '프로필 정보를 수정했습니다.',
+  FAIL_EDIT_PROFILE: '프로필 정보 수정에 실패했습니다.',
 };
 
 export const CONFIRM_MSG = {

--- a/frontend/src/context/dialog/DialogProvider.styles.ts
+++ b/frontend/src/context/dialog/DialogProvider.styles.ts
@@ -40,6 +40,10 @@ const DialogInner = styled.div`
   text-align: center;
   position: relative;
   overflow: hidden;
+
+  & .message {
+    padding: 0 1.5rem;
+  }
 `;
 
 const TopBar = styled.div`

--- a/frontend/src/context/dialog/DialogProvider.tsx
+++ b/frontend/src/context/dialog/DialogProvider.tsx
@@ -76,7 +76,7 @@ const DialogProvider = ({ children }: Props) => {
         <Styled.TopBar>
           <Styled.AlertTitle>알림</Styled.AlertTitle>
         </Styled.TopBar>
-        <div>{message}</div>
+        <div className="message">{message}</div>
         <Styled.ButtonsContainer>{dialogButtonMap[dialogType]}</Styled.ButtonsContainer>
       </Styled.DialogInner>
     </Styled.DialogContainer>

--- a/frontend/src/hooks/queries/profile/useNicknameCheck.ts
+++ b/frontend/src/hooks/queries/profile/useNicknameCheck.ts
@@ -1,0 +1,38 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+
+import api from 'constants/api';
+import { ErrorHandler, Tech } from 'types';
+import HttpError from 'utils/HttpError';
+import { resolveHttpErrorResponse } from 'utils/error';
+
+interface CustomQueryOption extends UseQueryOptions<Tech[], HttpError> {
+  nickname: string;
+  errorHandler?: ErrorHandler;
+}
+
+const checkNicknameUsable = async (nickname: string, errorHandler: ErrorHandler) => {
+  try {
+    const { data } = await api.get(`/members/me/profile/validation?nickname=${nickname}`);
+
+    return data;
+  } catch (error) {
+    resolveHttpErrorResponse({
+      errorResponse: error.response,
+      defaultErrorMessage: '닉네임 중복검사 과정에서 에러가 발생했습니다',
+      errorHandler,
+    });
+  }
+};
+
+const useNicknameCheck = ({ nickname, errorHandler }: CustomQueryOption) => {
+  return useQuery<{ isUsable: boolean }>(
+    ['nicknameCheck', nickname],
+    () => checkNicknameUsable(nickname, errorHandler),
+    {
+      enabled: !!nickname,
+      suspense: false,
+    },
+  );
+};
+
+export default useNicknameCheck;

--- a/frontend/src/hooks/queries/profile/useNotiDelete.ts
+++ b/frontend/src/hooks/queries/profile/useNotiDelete.ts
@@ -1,0 +1,31 @@
+import { useMutation } from 'react-query';
+import { AxiosResponse } from 'axios';
+
+import api from 'constants/api';
+import HttpError from 'utils/HttpError';
+import { resolveHttpErrorResponse } from 'utils/error';
+
+interface Args {
+  notificationId?: number;
+}
+
+const deleteNoti = async ({ notificationId }: Args) => {
+  try {
+    const endpoint = notificationId
+      ? `/members/me/notifications/${notificationId}`
+      : '/members/me/notifications';
+
+    const { data } = await api.delete(endpoint);
+
+    return data;
+  } catch (error) {
+    resolveHttpErrorResponse({
+      errorResponse: error.response,
+      defaultErrorMessage: '알림 삭제 과정에서 에러가 발생했습니다',
+    });
+  }
+};
+
+export default function useNotiDelete() {
+  return useMutation<AxiosResponse<unknown>, HttpError, Args>(deleteNoti);
+}

--- a/frontend/src/hooks/queries/profile/useNotiLoad.ts
+++ b/frontend/src/hooks/queries/profile/useNotiLoad.ts
@@ -1,0 +1,30 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+
+import api from 'constants/api';
+import { ErrorHandler, Notification } from 'types';
+import HttpError from 'utils/HttpError';
+import { resolveHttpErrorResponse } from 'utils/error';
+
+interface CustomQueryOption extends UseQueryOptions<Notification[], HttpError> {
+  errorHandler?: ErrorHandler;
+}
+
+const getNotifications = async (errorHandler?: ErrorHandler) => {
+  try {
+    const { data } = await api.get('/members/me/notifications');
+
+    return data;
+  } catch (error) {
+    resolveHttpErrorResponse({
+      errorResponse: error.response,
+      defaultErrorMessage: '알림 목록을 불러오는 과정에서 에러가 발생했습니다',
+      errorHandler,
+    });
+  }
+};
+
+const useNotiLoad = ({ errorHandler, ...option }: CustomQueryOption) => {
+  return useQuery<Notification[]>('notification', () => getNotifications(errorHandler), option);
+};
+
+export default useNotiLoad;

--- a/frontend/src/hooks/queries/profile/useProfileEdit.ts
+++ b/frontend/src/hooks/queries/profile/useProfileEdit.ts
@@ -1,0 +1,29 @@
+import { useMutation } from 'react-query';
+import { AxiosResponse } from 'axios';
+
+import api from 'constants/api';
+import HttpError from 'utils/HttpError';
+import { resolveHttpErrorResponse } from 'utils/error';
+
+interface Args {
+  formData: FormData;
+}
+
+const editProfile = async ({ formData }: Args) => {
+  try {
+    const { data } = await api.put('members/me/profile', formData);
+
+    return data;
+  } catch (error) {
+    resolveHttpErrorResponse({
+      errorResponse: error.response,
+      defaultErrorMessage: '프로필 수정 과정에서 에러가 발생했습니다',
+    });
+  }
+};
+
+const useProfileEdit = () => {
+  return useMutation<AxiosResponse<unknown>, HttpError, Args>(editProfile);
+};
+
+export default useProfileEdit;

--- a/frontend/src/hooks/queries/profile/useProfileEdit.ts
+++ b/frontend/src/hooks/queries/profile/useProfileEdit.ts
@@ -11,7 +11,7 @@ interface Args {
 
 const editProfile = async ({ formData }: Args) => {
   try {
-    const { data } = await api.put('members/me/profile', formData);
+    const { data } = await api.put('/members/me/profile', formData);
 
     return data;
   } catch (error) {

--- a/frontend/src/hooks/queries/profile/useProfileLoad.ts
+++ b/frontend/src/hooks/queries/profile/useProfileLoad.ts
@@ -11,7 +11,7 @@ interface CustomQueryOption extends UseQueryOptions<Profile, HttpError> {
 
 const getProfile = async (errorHandler?: ErrorHandler) => {
   try {
-    const { data } = await api.get('members/me/profile');
+    const { data } = await api.get('/members/me/profile');
 
     return data;
   } catch (error) {

--- a/frontend/src/hooks/queries/profile/useProfileLoad.ts
+++ b/frontend/src/hooks/queries/profile/useProfileLoad.ts
@@ -1,0 +1,30 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+
+import api from 'constants/api';
+import { ErrorHandler, Profile } from 'types';
+import HttpError from 'utils/HttpError';
+import { resolveHttpErrorResponse } from 'utils/error';
+
+interface CustomQueryOption extends UseQueryOptions<Profile, HttpError> {
+  errorHandler?: ErrorHandler;
+}
+
+const getProfile = async (errorHandler?: ErrorHandler) => {
+  try {
+    const { data } = await api.get('members/me/profile');
+
+    return data;
+  } catch (error) {
+    resolveHttpErrorResponse({
+      errorResponse: error.response,
+      defaultErrorMessage: '사용자 프로필을 불러오는 과정에서 에러가 발생했습니다',
+      errorHandler,
+    });
+  }
+};
+
+const useProfileLoad = ({ errorHandler, ...option }: CustomQueryOption) => {
+  return useQuery<Profile>('profile', () => getProfile(errorHandler), option);
+};
+
+export default useProfileLoad;

--- a/frontend/src/hooks/queries/useMember.tsx
+++ b/frontend/src/hooks/queries/useMember.tsx
@@ -39,7 +39,7 @@ const useMember = () => {
     queryClient.resetQueries('member');
   };
 
-  const { data: userData } = useQuery<UserInfo>('member', getMember, {
+  const { data: userData, refetch: refetchMember } = useQuery<UserInfo>('member', getMember, {
     suspense: false,
     useErrorBoundary: false,
     onError: (error) => {
@@ -61,6 +61,7 @@ const useMember = () => {
     userData,
     isLogin,
     logout,
+    refetchMember,
   };
 };
 

--- a/frontend/src/hooks/queries/userHistory/useUserHistory.ts
+++ b/frontend/src/hooks/queries/userHistory/useUserHistory.ts
@@ -1,0 +1,30 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+
+import api from 'constants/api';
+import { ErrorHandler, UserHistory } from 'types';
+import HttpError from 'utils/HttpError';
+import { resolveHttpErrorResponse } from 'utils/error';
+
+interface CustomQueryOption extends UseQueryOptions<UserHistory, HttpError> {
+  errorHandler?: ErrorHandler;
+}
+
+const getHistory = async (errorHandler?: ErrorHandler) => {
+  try {
+    const { data } = await api.get('/members/me/history');
+
+    return data;
+  } catch (error) {
+    resolveHttpErrorResponse({
+      errorResponse: error.response,
+      defaultErrorMessage: '사용자 히스토리를 불러오는 과정에서 에러가 발생했습니다',
+      errorHandler,
+    });
+  }
+};
+
+const useUserHistory = ({ errorHandler, ...option }: CustomQueryOption) => {
+  return useQuery<UserHistory>('userHistory', () => getHistory(errorHandler), option);
+};
+
+export default useUserHistory;

--- a/frontend/src/pages/Mypage/History/History.styles.ts
+++ b/frontend/src/pages/Mypage/History/History.styles.ts
@@ -18,6 +18,7 @@ const SlideBar = styled.div`
   color: ${PALETTE.ORANGE_400};
   display: flex;
   border-bottom: 1px solid ${PALETTE.ORANGE_400};
+  margin: 0 auto;
 
   /* for slide */
   overflow-x: auto;

--- a/frontend/src/pages/Mypage/History/History.styles.ts
+++ b/frontend/src/pages/Mypage/History/History.styles.ts
@@ -6,7 +6,7 @@ import { hoverLayer } from 'commonStyles';
 
 const Root = styled.div`
   padding: 1rem 2rem;
-  width: 32rem;
+  width: 34rem;
   height: 24rem;
   border-radius: 0.75rem;
   box-shadow: 4px 4px 8px 4px rgba(85, 85, 85, 0.2);

--- a/frontend/src/pages/Mypage/History/History.styles.ts
+++ b/frontend/src/pages/Mypage/History/History.styles.ts
@@ -55,17 +55,14 @@ const SlideTitle = styled.span<{ selected: boolean }>`
 
 const FeedsSwipeArea = styled.div`
   display: flex;
+  height: calc(100% - 3rem);
   overflow-x: auto;
-  scroll-snap-type: x mandatory;
   scroll-behavior: smooth;
 
   &::-webkit-scrollbar {
     display: none;
   }
 
-  /* Hide scrollbar for IE, Edge and Firefox */
-  -ms-overflow-style: none;
-  scrollbar-width: none;
   pointer-events: none;
 
   * {
@@ -75,11 +72,13 @@ const FeedsSwipeArea = styled.div`
 
 const FeedContainer = styled.div`
   width: 100%;
-  display: flex;
-  flex-direction: column;
   margin-top: 0.5rem;
+  overflow-y: scroll;
 
-  scroll-snap-align: start;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
   flex-shrink: 0;
 `;
 
@@ -105,6 +104,7 @@ const FeedThumbnail = styled.img`
 `;
 
 const FeedContentWrapper = styled.div`
+  width: calc(100% - 2rem);
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -116,12 +116,25 @@ const FeedTitle = styled.div`
 
 const FeedContent = styled.div`
   font-size: 14px;
+  width: calc(100% - 2rem);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 `;
 
 const FeedComment = styled.div`
   display: flex;
   align-items: center;
   gap: 0.5rem;
+`;
+
+const NoFeedContent = styled.div`
+  display: flex;
+  height: 100%;
+
+  > span {
+    margin: auto;
+  }
 `;
 
 export default {
@@ -137,4 +150,5 @@ export default {
   FeedTitle,
   FeedContent,
   FeedComment,
+  NoFeedContent,
 };

--- a/frontend/src/pages/Mypage/History/History.tsx
+++ b/frontend/src/pages/Mypage/History/History.tsx
@@ -1,86 +1,38 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 
+import useUserHistory from 'hooks/queries/userHistory/useUserHistory';
+import useSnackBar from 'context/snackBar/useSnackBar';
+import ROUTE from 'constants/routes';
 import ReturnArrow from 'assets/arrowReturnRight.svg';
-import catImage from 'assets/catError.png';
-import charlieIcon from 'assets/team/charlie.png';
 import { Feed, FeedWithComment, UserHistoryType } from 'types';
 import Styled from './History.styles';
-
-const mockData = {
-  likedFeeds: [
-    {
-      id: 1,
-      title: 'title1',
-      content: 'content1',
-      step: 'PROGRESS',
-      sos: true,
-      thumbnailUrl: catImage,
-    },
-    {
-      id: 2,
-      title: 'title2',
-      content: 'content2',
-      step: 'COMPLETE',
-      sos: false,
-      thumbnailUrl: catImage,
-    },
-  ],
-  myFeeds: [
-    {
-      id: 1,
-      title: 'title1',
-      content: 'content1',
-      step: 'PROGRESS',
-      sos: true,
-      thumbnailUrl: charlieIcon,
-    },
-    {
-      id: 2,
-      title: 'title2',
-      content: 'content2',
-      step: 'COMPLETE',
-      sos: false,
-      thumbnailUrl: charlieIcon,
-    },
-  ],
-  myComments: [
-    {
-      feed: {
-        id: 1,
-        title: 'title1',
-        content: 'content1',
-        step: 'PROGRESS',
-        sos: true,
-        thumbnailUrl: catImage,
-      },
-      text: '댓글',
-    },
-    {
-      feed: {
-        id: 2,
-        title: 'title2',
-        content: 'content1',
-        step: 'PROGRESS',
-        sos: true,
-        thumbnailUrl: catImage,
-      },
-      text: '댓글2',
-    },
-  ],
-};
 
 const History = () => {
   const [tab, setTab] = useState<UserHistoryType>(UserHistoryType.MY_LIKED);
   const selectedTab = useRef(null);
+  const history = useHistory();
 
-  const { likedFeeds, myFeeds, myComments } = mockData;
+  const snackbar = useSnackBar();
+
+  const { data: historyData } = useUserHistory({
+    errorHandler: (error) => {
+      snackbar.addSnackBar('error', error.message);
+    },
+  });
+
+  const goFeedDetail = (feedId: Feed['id']) => {
+    history.push(`${ROUTE.FEEDS}/${feedId}`);
+  };
+
+  const { likedFeeds, myFeeds, myComments } = historyData;
 
   useEffect(() => {
     selectedTab?.current?.scrollIntoView();
   }, [selectedTab.current]);
 
   const feedWithContent = (feed: Omit<Feed, 'author'>): React.ReactNode => (
-    <Styled.FeedWrapper key={feed.id}>
+    <Styled.FeedWrapper key={feed.id} onClick={() => goFeedDetail(feed.id)}>
       <Styled.FeedThumbnail src={feed.thumbnailUrl} />
       <Styled.FeedContentWrapper>
         <Styled.FeedTitle>{feed.title}</Styled.FeedTitle>
@@ -90,7 +42,7 @@ const History = () => {
   );
 
   const feedWithComment = (feed: FeedWithComment): React.ReactNode => (
-    <Styled.FeedWrapper key={feed.feed.id}>
+    <Styled.FeedWrapper key={feed.feed.id} onClick={() => goFeedDetail(feed.feed.id)}>
       <Styled.FeedThumbnail src={feed.feed.thumbnailUrl} />
       <Styled.FeedContentWrapper>
         <Styled.FeedTitle>{feed.feed.title}</Styled.FeedTitle>
@@ -100,6 +52,12 @@ const History = () => {
         </Styled.FeedComment>
       </Styled.FeedContentWrapper>
     </Styled.FeedWrapper>
+  );
+
+  const noFeedContent: React.ReactNode = (
+    <Styled.NoFeedContent>
+      <span>🧐 게시글이 없습니다.</span>
+    </Styled.NoFeedContent>
   );
 
   return (
@@ -130,19 +88,25 @@ const History = () => {
           id={UserHistoryType.MY_LIKED}
           ref={tab === UserHistoryType.MY_LIKED ? selectedTab : null}
         >
-          {likedFeeds.map((feed) => feedWithContent(feed as Omit<Feed, 'author'>))}
+          {likedFeeds.length > 0
+            ? likedFeeds.map((feed) => feedWithContent(feed as Omit<Feed, 'author'>))
+            : noFeedContent}
         </Styled.FeedContainer>
         <Styled.FeedContainer
           id={UserHistoryType.MY_FEED}
           ref={tab === UserHistoryType.MY_FEED ? selectedTab : null}
         >
-          {myFeeds.map((feed) => feedWithContent(feed as Omit<Feed, 'author'>))}
+          {myFeeds.length > 0
+            ? myFeeds.map((feed) => feedWithContent(feed as Omit<Feed, 'author'>))
+            : noFeedContent}
         </Styled.FeedContainer>
         <Styled.FeedContainer
           id={UserHistoryType.MY_COMMENT}
           ref={tab === UserHistoryType.MY_COMMENT ? selectedTab : null}
         >
-          {myComments.map((feed) => feedWithComment(feed as FeedWithComment))}
+          {myComments.length > 0
+            ? myComments.map((feed) => feedWithComment(feed as FeedWithComment))
+            : noFeedContent}
         </Styled.FeedContainer>
       </Styled.FeedsSwipeArea>
     </Styled.Root>

--- a/frontend/src/pages/Mypage/History/History.tsx
+++ b/frontend/src/pages/Mypage/History/History.tsx
@@ -28,8 +28,8 @@ const History = () => {
   const { likedFeeds, myFeeds, myComments } = historyData;
 
   useEffect(() => {
-    selectedTab?.current?.scrollIntoView();
-  }, [selectedTab.current]);
+    selectedTab.current.scrollIntoView();
+  }, [tab]);
 
   const feedWithContent = (feed: Omit<Feed, 'author'>): React.ReactNode => (
     <Styled.FeedWrapper key={feed.id} onClick={() => goFeedDetail(feed.id)}>
@@ -89,7 +89,7 @@ const History = () => {
           ref={tab === UserHistoryType.MY_LIKED ? selectedTab : null}
         >
           {likedFeeds.length > 0
-            ? likedFeeds.map((feed) => feedWithContent(feed as Omit<Feed, 'author'>))
+            ? likedFeeds.map((feed: Omit<Feed, 'author'>) => feedWithContent(feed))
             : noFeedContent}
         </Styled.FeedContainer>
         <Styled.FeedContainer
@@ -97,7 +97,7 @@ const History = () => {
           ref={tab === UserHistoryType.MY_FEED ? selectedTab : null}
         >
           {myFeeds.length > 0
-            ? myFeeds.map((feed) => feedWithContent(feed as Omit<Feed, 'author'>))
+            ? myFeeds.map((feed: Omit<Feed, 'author'>) => feedWithContent(feed))
             : noFeedContent}
         </Styled.FeedContainer>
         <Styled.FeedContainer
@@ -105,7 +105,7 @@ const History = () => {
           ref={tab === UserHistoryType.MY_COMMENT ? selectedTab : null}
         >
           {myComments.length > 0
-            ? myComments.map((feed) => feedWithComment(feed as FeedWithComment))
+            ? myComments.map((feed: FeedWithComment) => feedWithComment(feed))
             : noFeedContent}
         </Styled.FeedContainer>
       </Styled.FeedsSwipeArea>

--- a/frontend/src/pages/Mypage/Intro/Intro.styles.ts
+++ b/frontend/src/pages/Mypage/Intro/Intro.styles.ts
@@ -1,9 +1,9 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { PALETTE } from 'constants/palette';
 import { hoverLayer } from 'commonStyles';
 
-const Root = styled.div`
+const Root = styled.form`
   display: flex;
   align-items: center;
   padding: 1rem 2rem;
@@ -14,18 +14,20 @@ const Root = styled.div`
   box-shadow: 4px 4px 8px 4px rgba(85, 85, 85, 0.2);
 `;
 
-const ImageWrapper = styled.form`
+const ImageWrapper = styled.div`
   position: relative;
 `;
 
 const UserImage = styled.img`
   width: 6rem;
+  height: 6rem;
+  object-fit: cover;
   border-radius: 50%;
 `;
 
 const CameraLabel = styled.label`
   position: absolute;
-  left: 0.75rem;
+  left: 0.35rem;
   bottom: 0.75rem;
   background: ${PALETTE.WHITE_400};
   width: 1.25rem;
@@ -55,25 +57,42 @@ const TopContainer = styled.div`
   gap: 1rem;
 `;
 
-const Name = styled.div<{ isEditing: boolean }>`
+const nameStyle = css`
   font-size: 18px;
   font-weight: 700;
   width: 100%;
   padding-bottom: 0.25rem;
-  border-bottom: ${({ isEditing }) => isEditing && `1px solid ${PALETTE.BLACK_100}`};
+`;
+
+const Name = styled.div`
+  ${nameStyle};
+`;
+
+const NameInput = styled.input`
+  ${nameStyle};
+  border: none;
+  border-bottom: 1px solid ${PALETTE.BLACK_100};
 
   &:focus {
     outline: none;
   }
 `;
 
-const EditButton = styled.button`
+const editButtonStyle = css`
   background: transparent;
   border: none;
   flex-shrink: 0;
   color: ${PALETTE.GRAY_500};
 
   ${hoverLayer({})};
+`;
+
+const EditButton = styled.button`
+  ${editButtonStyle};
+`;
+
+const EditDoneButton = styled.button`
+  ${editButtonStyle};
 `;
 
 const ValidationMessage = styled.span<{ isValid: boolean }>`
@@ -85,15 +104,23 @@ const DetailContainer = styled.div`
   margin-top: 1rem;
 `;
 
-const DetailText = styled.div<{ isEditing?: boolean }>`
-  font-size: 0.75rem;
+const detailStyle = css`
+  font-size: 0.85rem;
   color: ${PALETTE.BLACK_200};
   padding-bottom: 0.25rem;
-  border-bottom: ${({ isEditing }) => isEditing && `1px solid ${PALETTE.BLACK_100}`};
+`;
+
+const DetailText = styled.div`
+  ${detailStyle};
+`;
+
+const BioInput = styled.input`
+  ${detailStyle};
+  border: none;
+  border-bottom: 1px solid ${PALETTE.BLACK_200};
 
   &:focus {
     outline: none;
-    border-bottom: 1px solid ${PALETTE.BLACK_200};
   }
 `;
 
@@ -105,8 +132,11 @@ export default {
   Content,
   TopContainer,
   Name,
+  NameInput,
   EditButton,
+  EditDoneButton,
   ValidationMessage,
   DetailContainer,
   DetailText,
+  BioInput,
 };

--- a/frontend/src/pages/Mypage/Intro/Intro.styles.ts
+++ b/frontend/src/pages/Mypage/Intro/Intro.styles.ts
@@ -8,7 +8,7 @@ const Root = styled.form`
   align-items: center;
   padding: 1rem 2rem;
   gap: 2rem;
-  width: 32rem;
+  width: 34rem;
   height: 10rem;
   border-radius: 0.75rem;
   box-shadow: 4px 4px 8px 4px rgba(85, 85, 85, 0.2);

--- a/frontend/src/pages/Mypage/Intro/Intro.tsx
+++ b/frontend/src/pages/Mypage/Intro/Intro.tsx
@@ -1,50 +1,185 @@
 import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
 
-import zigIcon from 'assets/team/zig.png';
+import useProfileLoad from 'hooks/queries/profile/useProfileLoad';
+import useProfileEdit from 'hooks/queries/profile/useProfileEdit';
+import useMember from 'hooks/queries/useMember';
+import useNicknameCheck from 'hooks/queries/profile/useNicknameCheck';
+import useQueryDebounce from 'hooks/@common/useQueryDebounce';
+import useSnackBar from 'context/snackBar/useSnackBar';
+import useDialog from 'context/dialog/useDialog';
+import { ALERT_MSG } from 'constants/message';
 import Camera from 'assets/camera.svg';
 import NoteEdit from 'assets/noteEdit.svg';
 import Styled from './Intro.styles';
+import { THUMBNAIL_EXTENSION } from 'constants/common';
+
+type ProfileToUpload = {
+  nickname: string;
+  bio?: string;
+  image?: File;
+};
 
 const Intro = () => {
   const [isEditing, setIsEditing] = useState(false);
 
+  const snackbar = useSnackBar();
+  const dialog = useDialog();
+
+  const { refetchMember } = useMember();
+
+  const { data: profile, refetch: refetchProfile } = useProfileLoad({
+    errorHandler: (error) => {
+      snackbar.addSnackBar('error', error.message);
+    },
+  });
+
+  const [previewImage, setPreviewImage] = useState(profile.imageUrl);
+
+  const editMutation = useProfileEdit();
+
+  const { nickname, bio } = profile;
+
+  const { register, handleSubmit, setValue, watch } = useForm<ProfileToUpload>({
+    defaultValues: { nickname, bio },
+  });
+
+  const debouncedNickname = useQueryDebounce(watch('nickname'), 200);
+  const { data: nicknameCheck } = useNicknameCheck({
+    nickname: debouncedNickname,
+    errorHandler: (error) => snackbar.addSnackBar('error', error.message),
+  });
+
+  const setFileInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.currentTarget.files[0];
+
+    if (!THUMBNAIL_EXTENSION.includes(file.type)) {
+      dialog.alert('잘못된 확장자입니다.');
+
+      return;
+    }
+
+    const reader = new FileReader();
+
+    reader.onloadend = (event) => {
+      setPreviewImage(event.target.result as string);
+    };
+
+    if (file) {
+      reader.readAsDataURL(file);
+    }
+
+    setValue('image', file);
+  };
+
+  const editProfile = (data: ProfileToUpload) => {
+    const formData = new FormData();
+
+    Object.keys(data).forEach((key: keyof typeof data) => {
+      formData.append(key, data[key]);
+    });
+
+    editMutation.mutate(
+      { formData },
+      {
+        onSuccess: () => {
+          snackbar.addSnackBar('success', ALERT_MSG.SUCCESS_EDIT_PROFILE);
+          refetchProfile();
+          refetchMember();
+        },
+        onError: () => snackbar.addSnackBar('error', ALERT_MSG.FAIL_EDIT_PROFILE),
+      },
+    );
+
+    setIsEditing(false);
+  };
+
+  const nicknameValidation = () => {
+    if (nicknameCheck?.isUsable) {
+      if (watch('nickname').length >= 10) {
+        return {
+          isValid: false,
+          message: '닉네임을 10글자 미만으로 입력해주세요.',
+        };
+      } else {
+        return {
+          isValid: true,
+          message: '사용 가능한 닉네임입니다.',
+        };
+      }
+    } else {
+      if (watch('nickname').length < 2) {
+        return {
+          isValid: false,
+          message: '닉네임을 2글자 이상 입력해주세요.',
+        };
+      } else {
+        return {
+          isValid: false,
+          message: '이미 사용중인 닉네임입니다.',
+        };
+      }
+    }
+  };
+
+  const createdAt = new Date(profile.createdAt);
+
+  const joinedAt =
+    createdAt.getFullYear() + '.' + (createdAt.getMonth() + 1) + '.' + createdAt.getDate();
+
   return (
-    <Styled.Root>
+    <Styled.Root onSubmit={handleSubmit(editProfile)}>
       <Styled.ImageWrapper>
-        <Styled.UserImage src={zigIcon} />
-        {isEditing && (
-          <Styled.CameraLabel>
-            <input type="file" />
-            <Camera width="14px" />
-          </Styled.CameraLabel>
+        {isEditing ? (
+          <>
+            <Styled.UserImage src={previewImage} />
+            <Styled.CameraLabel>
+              <input type="file" onChange={setFileInput} accept={THUMBNAIL_EXTENSION.join(',')} />
+              <Camera width="14px" />
+            </Styled.CameraLabel>
+          </>
+        ) : (
+          <Styled.UserImage src={profile.imageUrl} />
         )}
       </Styled.ImageWrapper>
 
       <Styled.Content>
         <Styled.TopContainer>
-          <Styled.Name contentEditable={isEditing} spellCheck={false} isEditing={isEditing}>
-            Jieun Song
-          </Styled.Name>
           {isEditing ? (
-            <Styled.EditButton type="button" onClick={() => setIsEditing(false)}>
-              <span>수정</span>
-            </Styled.EditButton>
+            <>
+              <Styled.NameInput
+                {...register('nickname', { minLength: 2, maxLength: 10 })}
+                spellCheck={false}
+              />
+              <Styled.EditDoneButton>
+                <span>수정</span>
+              </Styled.EditDoneButton>
+            </>
           ) : (
-            <Styled.EditButton type="button" onClick={() => setIsEditing(true)}>
-              <NoteEdit width="18px" />
-            </Styled.EditButton>
+            <>
+              <Styled.Name>{profile.nickname}</Styled.Name>
+              <Styled.EditButton type="button" onClick={() => setIsEditing(true)}>
+                <NoteEdit width="18px" />
+              </Styled.EditButton>
+            </>
           )}
         </Styled.TopContainer>
-        {isEditing && (
-          <Styled.ValidationMessage isValid={false}>
-            이미 사용중인 닉네임입니다.
+        {isEditing && nickname !== watch('nickname') && (
+          <Styled.ValidationMessage isValid={nicknameValidation().isValid}>
+            {nicknameValidation().message}
           </Styled.ValidationMessage>
         )}
         <Styled.DetailContainer>
-          <Styled.DetailText>Joined at 2021.07.22</Styled.DetailText>
-          <Styled.DetailText contentEditable={isEditing} spellCheck={false} isEditing={isEditing}>
-            안녕하세요 지그입니다
-          </Styled.DetailText>
+          <Styled.DetailText>Joined at {joinedAt}</Styled.DetailText>
+          {isEditing ? (
+            <Styled.BioInput
+              {...register('bio')}
+              placeholder={watch('bio') || '소개를 입력해 주세요.'}
+              spellCheck={false}
+            />
+          ) : (
+            <Styled.DetailText>{profile.bio || '소개를 입력해 주세요.'}</Styled.DetailText>
+          )}
         </Styled.DetailContainer>
       </Styled.Content>
     </Styled.Root>

--- a/frontend/src/pages/Mypage/Intro/Intro.tsx
+++ b/frontend/src/pages/Mypage/Intro/Intro.tsx
@@ -84,7 +84,7 @@ const Intro = () => {
       {
         onSuccess: () => {
           snackbar.addSnackBar('success', ALERT_MSG.SUCCESS_EDIT_PROFILE);
-          refetchProfile();
+          refetchProfile({ throwOnError: true });
           refetchMember();
         },
         onError: () => snackbar.addSnackBar('error', ALERT_MSG.FAIL_EDIT_PROFILE),
@@ -95,31 +95,31 @@ const Intro = () => {
   };
 
   const nicknameValidation = () => {
-    if (nicknameCheck?.isUsable) {
-      if (watch('nickname').length >= 10) {
-        return {
-          isValid: false,
-          message: '닉네임을 10글자 미만으로 입력해주세요.',
-        };
-      } else {
-        return {
-          isValid: true,
-          message: '사용 가능한 닉네임입니다.',
-        };
-      }
-    } else {
-      if (watch('nickname').length < 2) {
-        return {
-          isValid: false,
-          message: '닉네임을 2글자 이상 입력해주세요.',
-        };
-      } else {
-        return {
-          isValid: false,
-          message: '이미 사용중인 닉네임입니다.',
-        };
-      }
+    if (watch('nickname').length >= 10) {
+      return {
+        isValid: false,
+        message: '닉네임을 10글자 미만으로 입력해주세요.',
+      };
     }
+
+    if (watch('nickname').length < 2) {
+      return {
+        isValid: false,
+        message: '닉네임을 2글자 이상 입력해주세요.',
+      };
+    }
+
+    if (!nicknameCheck?.isUsable) {
+      return {
+        isValid: false,
+        message: '이미 사용중인 닉네임입니다.',
+      };
+    }
+
+    return {
+      isValid: true,
+      message: '사용 가능한 닉네임입니다',
+    };
   };
 
   const createdAt = new Date(profile.createdAt);

--- a/frontend/src/pages/Mypage/Mypage.tsx
+++ b/frontend/src/pages/Mypage/Mypage.tsx
@@ -19,7 +19,11 @@ const Mypage = () => {
           <Intro />
         </AsyncBoundary>
         <Notification />
-        <History />
+        <AsyncBoundary
+          rejectedFallback={<ErrorFallback message="사용자 히스토리를 가져올 수 없습니다." />}
+        >
+          <History />
+        </AsyncBoundary>
       </Styled.Root>
     </>
   );

--- a/frontend/src/pages/Mypage/Mypage.tsx
+++ b/frontend/src/pages/Mypage/Mypage.tsx
@@ -18,7 +18,11 @@ const Mypage = () => {
         >
           <Intro />
         </AsyncBoundary>
-        <Notification />
+        <AsyncBoundary
+          rejectedFallback={<ErrorFallback message="알림 목록을 가져올 수 없습니다." />}
+        >
+          <Notification />
+        </AsyncBoundary>
         <AsyncBoundary
           rejectedFallback={<ErrorFallback message="사용자 히스토리를 가져올 수 없습니다." />}
         >

--- a/frontend/src/pages/Mypage/Mypage.tsx
+++ b/frontend/src/pages/Mypage/Mypage.tsx
@@ -4,6 +4,8 @@ import Intro from './Intro/Intro';
 import Notification from './Notification/Notification';
 import History from './History/History';
 import Header from 'components/Header/Header';
+import AsyncBoundary from 'components/AsyncBoundary';
+import ErrorFallback from 'components/ErrorFallback/ErrorFallback';
 import Styled from './Mypage.styles';
 
 const Mypage = () => {
@@ -11,7 +13,11 @@ const Mypage = () => {
     <>
       <Header />
       <Styled.Root>
-        <Intro />
+        <AsyncBoundary
+          rejectedFallback={<ErrorFallback message="사용자 데이터를 가져올 수 없습니다." />}
+        >
+          <Intro />
+        </AsyncBoundary>
         <Notification />
         <History />
       </Styled.Root>

--- a/frontend/src/pages/Mypage/Notification/Notification.styles.ts
+++ b/frontend/src/pages/Mypage/Notification/Notification.styles.ts
@@ -8,12 +8,12 @@ const Root = styled.div<{ isFolded: boolean; notiCount: number }>`
   padding: 1rem 2rem;
   width: 32rem;
   height: ${({ isFolded, notiCount }) =>
-    isFolded ? '12rem' : `calc(12rem + ${notiCount - 3} * 1rem)`};
+    isFolded ? '11rem' : `calc(11rem + ${notiCount - 3} * 1.75rem)`};
   border-radius: 0.75rem;
   box-shadow: 4px 4px 8px 4px rgba(85, 85, 85, 0.2);
   display: flex;
   flex-direction: column;
-  transition: height 0.3s ease;
+  transition: height 0.2s ease;
 `;
 
 const TopContainer = styled.div`
@@ -120,6 +120,14 @@ const MoreNotiButton = styled.button`
   }
 `;
 
+const NoNotiContent = styled.div`
+  display: flex;
+
+  > span {
+    margin: auto;
+  }
+`;
+
 export default {
   Root,
   TopContainer,
@@ -134,4 +142,5 @@ export default {
   NotiBold,
   DeleteNotiButton,
   MoreNotiButton,
+  NoNotiContent,
 };

--- a/frontend/src/pages/Mypage/Notification/Notification.styles.ts
+++ b/frontend/src/pages/Mypage/Notification/Notification.styles.ts
@@ -6,7 +6,7 @@ import ArrowIcon from 'assets/carouselArrow.svg';
 const Root = styled.div<{ isFolded: boolean; notiCount: number }>`
   position: relative;
   padding: 1rem 2rem;
-  width: 32rem;
+  width: 34rem;
   height: ${({ isFolded, notiCount }) =>
     isFolded ? '11rem' : `calc(11rem + ${notiCount - 3} * 1.75rem)`};
   border-radius: 0.75rem;

--- a/frontend/src/pages/Mypage/Notification/Notification.tsx
+++ b/frontend/src/pages/Mypage/Notification/Notification.tsx
@@ -6,6 +6,7 @@ import { PALETTE } from 'constants/palette';
 import useSnackbar from 'context/snackBar/useSnackBar';
 import useNotiLoad from 'hooks/queries/profile/useNotiLoad';
 import useNotiDelete from 'hooks/queries/profile/useNotiDelete';
+import useMember from 'hooks/queries/useMember';
 import { NotiType } from 'types';
 import Styled, { MoreNotiIcon } from './Notification.styles';
 
@@ -26,13 +27,18 @@ const Notification = () => {
     },
   });
 
+  const { refetchMember } = useMember();
+
   const deleteMutation = useNotiDelete();
 
   const deleteNoti = (notificationId?: number) => {
     deleteMutation.mutate(
       { notificationId },
       {
-        onSuccess: () => refetchNoti(),
+        onSuccess: () => {
+          refetchMember();
+          refetchNoti();
+        },
         onError: (error) => {
           snackbar.addSnackBar('error', error.message);
         },

--- a/frontend/src/pages/Mypage/Notification/Notification.tsx
+++ b/frontend/src/pages/Mypage/Notification/Notification.tsx
@@ -37,7 +37,7 @@ const Notification = () => {
       {
         onSuccess: () => {
           refetchMember();
-          refetchNoti();
+          refetchNoti({ throwOnError: true });
         },
         onError: (error) => {
           snackbar.addSnackBar('error', error.message);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -79,6 +79,12 @@ export interface UserInfo extends Author {
   socialType: 'GOOGLE' | 'GITHUB';
 }
 
+export interface Profile extends Author {
+  bio: string;
+  notifications: number;
+  createdAt: string;
+}
+
 export type OAuthType = 'google' | 'github';
 
 export type SnackBarType = 'error' | 'success' | null;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -130,3 +130,13 @@ export interface UserHistory {
   myFeeds: Omit<Feed, 'author'>[];
   myComments: FeedWithComment[];
 }
+
+export interface Notification {
+  id: number;
+  user: Author;
+  feed: {
+    id: number;
+    title: string;
+  };
+  type: NotiType;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -124,3 +124,9 @@ export interface RootComment extends CommentBase {
   helper: boolean;
   replies: CommentBase[];
 }
+
+export interface UserHistory {
+  likedFeeds: Omit<Feed, 'author'>[];
+  myFeeds: Omit<Feed, 'author'>[];
+  myComments: FeedWithComment[];
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -76,7 +76,7 @@ export interface FeedWithComment {
   text: string;
 }
 export interface UserInfo extends Author {
-  socialType: 'GOOGLE' | 'GITHUB';
+  notifications: number;
 }
 
 export interface Profile extends Author {


### PR DESCRIPTION
## 작업 내용
Mypage의 Intro, History api 연동

Closes #358
Closes #359
Closes #378

(8/8 추가) Closes #388
(8/8 추가) Closes #389 

## 스크린샷
<img src="https://media.giphy.com/media/1QtSXOr82jpNDeqQcT/giphy.gif" width="840px" />
<img src="https://media.giphy.com/media/VTkSabThT10UWnvFYq/giphy.gif" width="840px" />
<img src="https://media.giphy.com/media/WcvDJBIONuYtz4Qa94/giphy.gif" width="840px" />

(8/8 추가)
<img src="https://media.giphy.com/media/PuzHFd0C97M79R1EQG/giphy.gif" width="840px" />


## 주의사항
- `History`에서 메뉴 간 이동 시 한번에 제대로 되지 않는 이슈 있음
- `History`에서 스크롤바를 만들어주고 싶었으나 좌우 탭 이동시 스크롤바가 꼬이는 문제가 있어 일단 보류
- `UserInfo` 타입에서 `socialType`을 빼고 `notifications`를 넣어줌 (서버 api와 통일) 
- dialog에 padding 값 부여
