### PR TITLE
[FE] fix: errorfallback의 메시지 중앙 정렬 수정

### DIFF
--- a/frontend/src/components/ErrorFallback/ErrorFallback.styles.ts
+++ b/frontend/src/components/ErrorFallback/ErrorFallback.styles.ts
@@ -20,12 +20,12 @@ const Blur = styled.div`
   filter: blur(4px);
   position: absolute;
   width: 100%;
-  height: 100%;
 `;
 
 const Message = styled.div`
   color: inherit;
   position: absolute;
+  text-align: center;
   top: 40%;
 `;
 


### PR DESCRIPTION
## 작업 내용
error 글씨가 왼쪽으로 쏠려 있었음
-> 중앙 정렬 맞춤!

## 스크린샷
![image](https://user-images.githubusercontent.com/44080404/128472008-8c827a58-3169-4957-a6af-4e424d262f65.png)

