### PR TITLE
feat: 알림 기능 구현

### DIFF
--- a/backend/src/docs/asciidoc/tech.adoc
+++ b/backend/src/docs/asciidoc/tech.adoc
@@ -13,6 +13,8 @@ include::{snippets}/tech-findByTechsContains/http-response.adoc[]
 
 include::{snippets}/tech-findByTechsContains/response-fields.adoc[]
 
+=== 기술 스택 목록 조회 2
+
 ==== Request
 
 include::{snippets}/tech-findAllByNameInIgnoreCase/http-request.adoc[]
@@ -25,3 +27,17 @@ include::{snippets}/tech-findAllByNameInIgnoreCase/http-response.adoc[]
 ==== Response Fields
 
 include::{snippets}/tech-findAllByNameInIgnoreCase/response-fields.adoc[]
+
+=== 최신 스택 목록 조회
+
+==== Request
+
+include::{snippets}/tech-findTrendTechs/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/tech-findTrendTechs/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/tech-findTrendTechs/response-fields.adoc[]

--- a/backend/src/main/java/com/wooteco/nolto/NoltoApplication.java
+++ b/backend/src/main/java/com/wooteco/nolto/NoltoApplication.java
@@ -3,7 +3,9 @@ package com.wooteco.nolto;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
 public class NoltoApplication {

--- a/backend/src/main/java/com/wooteco/nolto/exception/ErrorType.java
+++ b/backend/src/main/java/com/wooteco/nolto/exception/ErrorType.java
@@ -32,7 +32,9 @@ public enum ErrorType {
     ALREADY_LIKED_COMMENT("comment-004", "이미 좋아요 누른 댓글 입니다."),
     NOT_LIKED_COMMENT("comment-005", "좋아요를 누르지 않은 댓글입니다."),
 
-    ALREADY_EXIST_NICKNAME("member-001", "이미 존재하는 닉네임입니다.");
+    ALREADY_EXIST_NICKNAME("member-001", "이미 존재하는 닉네임입니다."),
+    NOTIFICATION_NOT_FOUND("member-002", "존재하지 않는 알림입니다."),
+    UNAUTHORIZED_DELETE_NOTIFICATION("member-003", "알림은 본인만 삭제할 수 있습니다.");
 
     private String errorCode;
     private String message;

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
@@ -45,9 +45,17 @@ public class CommentService {
 
     public CommentResponse updateComment(Long commentId, CommentRequest request, User user) {
         Comment findComment = findEntityById(commentId);
+        notifyWhenChangedToHelper(request, findComment, user);
         findComment.update(request.getContent(), request.isHelper());
         commentRepository.flush();
         return CommentResponse.of(findComment, user);
+    }
+
+    private void notifyWhenChangedToHelper(CommentRequest request, Comment findComment, User user) {
+        boolean isChanged = findComment.changedToHelper(request.isHelper());
+        if (isChanged) {
+            applicationEventPublisher.publishEvent(NotificationEvent.commentOf(findComment.getFeed(), user, request.isHelper()));
+        }
     }
 
     public void deleteComment(Long commentId) {

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
@@ -7,8 +7,10 @@ import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.repository.CommentRepository;
 import com.wooteco.nolto.feed.ui.dto.*;
+import com.wooteco.nolto.notification.application.NotificationEvent;
 import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,12 +24,14 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final FeedService feedService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public CommentResponse createComment(User user, Long feedId, CommentRequest request) {
         Feed findFeed = feedService.findEntityById(feedId);
         Comment comment = new Comment(request.getContent(), request.isHelper()).writtenBy(user);
         findFeed.addComment(comment);
         commentRepository.save(comment);
+        applicationEventPublisher.publishEvent(NotificationEvent.commentOf(findFeed, user, request.isHelper()));
         return CommentResponse.of(comment, user);
     }
 

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/LikeService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/LikeService.java
@@ -4,8 +4,11 @@ import com.wooteco.nolto.exception.BadRequestException;
 import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.Like;
+import com.wooteco.nolto.notification.application.NotificationEvent;
+import com.wooteco.nolto.notification.domain.NotificationType;
 import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -14,7 +17,9 @@ import javax.transaction.Transactional;
 @AllArgsConstructor
 @Service
 public class LikeService {
+
     private final FeedService feedService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public void addLike(User user, Long feedId) {
         Feed findFeed = feedService.findEntityById(feedId);
@@ -22,6 +27,7 @@ public class LikeService {
             throw new BadRequestException(ErrorType.ALREADY_LIKED);
         }
         user.addLike(new Like(user, findFeed));
+        applicationEventPublisher.publishEvent(new NotificationEvent(findFeed, user, NotificationType.LIKE));
     }
 
     public void deleteLike(User user, Long feedId) {

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
@@ -122,4 +122,8 @@ public class Comment extends BaseEntity {
     public int hashCode() {
         return Objects.hash(id);
     }
+
+    public boolean changedToHelper(boolean helper) {
+        return !this.helper && this.helper != helper;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEvent.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEvent.java
@@ -1,0 +1,20 @@
+package com.wooteco.nolto.notification.application;
+
+import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.notification.domain.Notification;
+import com.wooteco.nolto.notification.domain.NotificationType;
+import com.wooteco.nolto.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class NotificationEvent {
+    private final Feed feed;
+    private final User publisher;
+    private final NotificationType notificationType;
+
+    public Notification toEntity() {
+        return new Notification(feed.getAuthor(), feed, publisher, notificationType);
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEvent.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEvent.java
@@ -17,4 +17,8 @@ public class NotificationEvent {
     public Notification toEntity() {
         return new Notification(feed.getAuthor(), feed, publisher, notificationType);
     }
+
+    public static NotificationEvent commentOf(Feed feed, User publisher, boolean isHelper) {
+        return new NotificationEvent(feed, publisher, NotificationType.findCommentBy(isHelper));
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEventHandler.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEventHandler.java
@@ -1,6 +1,7 @@
 package com.wooteco.nolto.notification.application;
 
 import lombok.AllArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -10,6 +11,7 @@ public class NotificationEventHandler {
 
     private final NotificationService notificationService;
 
+    @Async
     @TransactionalEventListener
     public void saveNotification(NotificationEvent notificationEvent) {
         notificationService.save(notificationEvent);

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEventHandler.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEventHandler.java
@@ -1,0 +1,17 @@
+package com.wooteco.nolto.notification.application;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@AllArgsConstructor
+public class NotificationEventHandler {
+
+    private final NotificationService notificationService;
+
+    @TransactionalEventListener
+    public void saveNotification(NotificationEvent notificationEvent) {
+        notificationService.save(notificationEvent);
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
@@ -1,5 +1,8 @@
 package com.wooteco.nolto.notification.application;
 
+import com.wooteco.nolto.exception.BadRequestException;
+import com.wooteco.nolto.exception.ErrorType;
+import com.wooteco.nolto.exception.NotFoundException;
 import com.wooteco.nolto.notification.domain.Notification;
 import com.wooteco.nolto.notification.domain.NotificationRepository;
 import com.wooteco.nolto.user.domain.User;
@@ -23,5 +26,20 @@ public class NotificationService {
 
     public List<Notification> findAllByUser(User user) {
         return notificationRepository.findAllByListener(user);
+    }
+
+    public void delete(User user, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotFoundException(ErrorType.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.isListener(user)) {
+            throw new BadRequestException(ErrorType.UNAUTHORIZED_DELETE_NOTIFICATION);
+        }
+
+        notificationRepository.delete(notification);
+    }
+
+    public void deleteAll(User user) {
+        notificationRepository.deleteAllByListener(user);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
@@ -42,4 +42,8 @@ public class NotificationService {
     public void deleteAll(User user) {
         notificationRepository.deleteAllByListener(user);
     }
+
+    public long findNotificationCount(User user) {
+        return notificationRepository.countByListener(user);
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
@@ -2,9 +2,12 @@ package com.wooteco.nolto.notification.application;
 
 import com.wooteco.nolto.notification.domain.Notification;
 import com.wooteco.nolto.notification.domain.NotificationRepository;
+import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -16,5 +19,9 @@ public class NotificationService {
     public void save(NotificationEvent notificationEvent) {
         Notification notification = notificationEvent.toEntity();
         notificationRepository.save(notification);
+    }
+
+    public List<Notification> findAllByUser(User user) {
+        return notificationRepository.findAllByListener(user);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
@@ -1,0 +1,20 @@
+package com.wooteco.nolto.notification.application;
+
+import com.wooteco.nolto.notification.domain.Notification;
+import com.wooteco.nolto.notification.domain.NotificationRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@AllArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public void save(NotificationEvent notificationEvent) {
+        Notification notification = notificationEvent.toEntity();
+        notificationRepository.save(notification);
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
@@ -1,5 +1,6 @@
 package com.wooteco.nolto.notification.domain;
 
+import com.wooteco.nolto.BaseEntity;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
@@ -12,7 +13,7 @@ import javax.persistence.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-public class Notification {
+public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
@@ -38,4 +38,8 @@ public class Notification {
         this.publisher = publisher;
         this.notificationType = notificationType;
     }
+
+    public boolean isListener(User user) {
+        return this.listener.sameAs(user);
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 
 @Entity
 @AllArgsConstructor
@@ -31,6 +32,7 @@ public class Notification extends BaseEntity {
     private User publisher;
 
     @Enumerated(EnumType.STRING)
+    @NotNull
     private NotificationType notificationType;
 
     public Notification(User listener, Feed feed, User publisher, NotificationType notificationType) {

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
@@ -14,7 +14,7 @@ import javax.persistence.*;
 @Getter
 public class Notification {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
@@ -1,0 +1,41 @@
+package com.wooteco.nolto.notification.domain;
+
+import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class Notification {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private User listener;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Feed feed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private User publisher;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    public Notification(User listener, Feed feed, User publisher, NotificationType notificationType) {
+        this.listener = listener;
+        this.feed = feed;
+        this.publisher = publisher;
+        this.notificationType = notificationType;
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationRepository.java
@@ -1,6 +1,10 @@
 package com.wooteco.nolto.notification.domain;
 
+import com.wooteco.nolto.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findAllByListener(User listener);
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findAllByListener(User listener);
+
+    void deleteAllByListener(User listener);
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationRepository.java
@@ -9,4 +9,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findAllByListener(User listener);
 
     void deleteAllByListener(User listener);
+
+    long countByListener(User user);
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationRepository.java
@@ -1,0 +1,6 @@
+package com.wooteco.nolto.notification.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationType.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationType.java
@@ -1,0 +1,5 @@
+package com.wooteco.nolto.notification.domain;
+
+public enum NotificationType {
+    COMMENT_SOS, COMMENT, LIKE
+}

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationType.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/NotificationType.java
@@ -1,5 +1,12 @@
 package com.wooteco.nolto.notification.domain;
 
 public enum NotificationType {
-    COMMENT_SOS, COMMENT, LIKE
+    COMMENT_SOS, COMMENT, LIKE;
+
+    public static NotificationType findCommentBy(boolean isHelper) {
+        if (isHelper) {
+            return COMMENT_SOS;
+        }
+        return COMMENT;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/tech/domain/Tech.java
+++ b/backend/src/main/java/com/wooteco/nolto/tech/domain/Tech.java
@@ -42,13 +42,4 @@ public class Tech {
     public int hashCode() {
         return Objects.hash(id, name);
     }
-
-    @Override
-    public String toString() {
-        return "Tech{" +
-                "id=" + id +
-                ", name='" + name + '\'' +
-                ", feeds=" + feeds +
-                '}';
-    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
@@ -62,4 +62,12 @@ public class MemberService {
     public List<NotificationResponse> findNotifications(User user) {
         return NotificationResponse.toList(notificationService.findAllByUser(user));
     }
+
+    public void deleteNotification(User user, Long notificationId) {
+        notificationService.delete(user, notificationId);
+    }
+
+    public void deleteAllNotifications(User user) {
+        notificationService.deleteAll(user);
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
@@ -41,8 +41,8 @@ public class MemberService {
     }
 
     public ProfileResponse findProfile(User user) {
-        // TODO user의 notifications 수 구하는 로직 필요, user도 가지고 있으면 Service 레이어까지 오지 않을 수 있음
-        return ProfileResponse.of(user, 0);
+        long notificationCount = notificationService.findNotificationCount(user);
+        return ProfileResponse.of(user, notificationCount);
     }
 
     public ProfileResponse updateProfile(User user, ProfileRequest request) {
@@ -73,5 +73,10 @@ public class MemberService {
 
     public void deleteAllNotifications(User user) {
         notificationService.deleteAll(user);
+    }
+
+    public MemberResponse findMemberOfMine(User user) {
+        long notificationCount = notificationService.findNotificationCount(user);
+        return MemberResponse.of(user, notificationCount);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
@@ -6,6 +6,7 @@ import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.image.application.ImageKind;
 import com.wooteco.nolto.image.application.ImageService;
 import com.wooteco.nolto.notification.application.NotificationService;
+import com.wooteco.nolto.notification.domain.Notification;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
 import com.wooteco.nolto.user.ui.dto.*;
@@ -13,6 +14,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 
 import static com.wooteco.nolto.exception.ErrorType.ALREADY_EXIST_NICKNAME;
@@ -60,7 +62,9 @@ public class MemberService {
     }
 
     public List<NotificationResponse> findNotifications(User user) {
-        return NotificationResponse.toList(notificationService.findAllByUser(user));
+        List<Notification> notifications = notificationService.findAllByUser(user);
+        notifications.sort(Comparator.comparing(Notification::getCreatedDate, Comparator.reverseOrder()));
+        return NotificationResponse.toList(notifications);
     }
 
     public void deleteNotification(User user, Long notificationId) {

--- a/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
@@ -5,12 +5,10 @@ import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.image.application.ImageKind;
 import com.wooteco.nolto.image.application.ImageService;
+import com.wooteco.nolto.notification.application.NotificationService;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
-import com.wooteco.nolto.user.ui.dto.MemberHistoryResponse;
-import com.wooteco.nolto.user.ui.dto.NicknameValidationResponse;
-import com.wooteco.nolto.user.ui.dto.ProfileRequest;
-import com.wooteco.nolto.user.ui.dto.ProfileResponse;
+import com.wooteco.nolto.user.ui.dto.*;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +23,7 @@ import static com.wooteco.nolto.exception.ErrorType.ALREADY_EXIST_NICKNAME;
 public class MemberService {
 
     private final ImageService imageService;
+    private final NotificationService notificationService;
     private final UserRepository userRepository;
 
     public MemberHistoryResponse findHistory(User user) {
@@ -58,5 +57,9 @@ public class MemberService {
 
         String updateImageUrl = imageService.update(user.getImageUrl(), request.getImage(), ImageKind.USER);
         user.changeImageUrl(updateImageUrl);
+    }
+
+    public List<NotificationResponse> findNotifications(User user) {
+        return NotificationResponse.toList(notificationService.findAllByUser(user));
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/MemberController.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/MemberController.java
@@ -2,6 +2,7 @@ package com.wooteco.nolto.user.ui;
 
 import com.wooteco.nolto.auth.MemberAuthenticationPrincipal;
 import com.wooteco.nolto.auth.ValidTokenRequired;
+import com.wooteco.nolto.notification.application.NotificationService;
 import com.wooteco.nolto.user.application.MemberService;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.ui.dto.*;
@@ -10,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/members/me")
@@ -52,5 +54,12 @@ public class MemberController {
     public ResponseEntity<ProfileResponse> updateProfileOfMine(@MemberAuthenticationPrincipal User user, @Valid @ModelAttribute ProfileRequest profileRequest) {
         ProfileResponse response = memberService.updateProfile(user, profileRequest);
         return ResponseEntity.ok(response);
+    }
+
+    @ValidTokenRequired
+    @GetMapping("/notifications")
+    public ResponseEntity<List<NotificationResponse>> findNotifications(@MemberAuthenticationPrincipal User user) {
+        List<NotificationResponse> notificationResponses = memberService.findNotifications(user);
+        return ResponseEntity.ok(notificationResponses);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/MemberController.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/MemberController.java
@@ -62,4 +62,18 @@ public class MemberController {
         List<NotificationResponse> notificationResponses = memberService.findNotifications(user);
         return ResponseEntity.ok(notificationResponses);
     }
+
+    @ValidTokenRequired
+    @DeleteMapping("/notifications/{notificationId:[\\d]+}")
+    public ResponseEntity<Void> deleteNotification(@MemberAuthenticationPrincipal User user, @PathVariable Long notificationId) {
+        memberService.deleteNotification(user, notificationId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @ValidTokenRequired
+    @DeleteMapping("/notifications")
+    public ResponseEntity<Void> deleteAllNotifications(@MemberAuthenticationPrincipal User user) {
+        memberService.deleteAllNotifications(user);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/MemberController.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/MemberController.java
@@ -23,8 +23,8 @@ public class MemberController {
     @ValidTokenRequired
     @GetMapping
     public ResponseEntity<MemberResponse> findMemberOfMine(@MemberAuthenticationPrincipal User user) {
-        // TODO user의 notifications 수 구하는 로직 필요, user안에서 notifications 가지고 있게 할것인과
-        return ResponseEntity.ok(MemberResponse.of(user));
+        MemberResponse response = memberService.findMemberOfMine(user);
+        return ResponseEntity.ok(response);
     }
 
     @ValidTokenRequired

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/FeedNotificationResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/FeedNotificationResponse.java
@@ -1,0 +1,17 @@
+package com.wooteco.nolto.user.ui.dto;
+
+import com.wooteco.nolto.feed.domain.Feed;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FeedNotificationResponse {
+
+    private final Long id;
+    private final String title;
+
+    public static FeedNotificationResponse of(Feed feed) {
+        return new FeedNotificationResponse(feed.getId(), feed.getTitle());
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/MemberResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/MemberResponse.java
@@ -10,9 +10,9 @@ public class MemberResponse {
     private final Long id;
     private final String nickname;
     private final String imageUrl;
-    private final int notifications;
+    private final long notifications;
 
-    public static MemberResponse of(User user) {
-        return new MemberResponse(user.getId(), user.getNickName(), user.getImageUrl(), 0);
+    public static MemberResponse of(User user, long notificationCount) {
+        return new MemberResponse(user.getId(), user.getNickName(), user.getImageUrl(), notificationCount);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/NotificationResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/NotificationResponse.java
@@ -1,0 +1,34 @@
+package com.wooteco.nolto.user.ui.dto;
+
+import com.wooteco.nolto.feed.ui.dto.AuthorResponse;
+import com.wooteco.nolto.notification.domain.Notification;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class NotificationResponse {
+
+    private final Long id;
+    private final AuthorResponse user;
+    private final FeedNotificationResponse feed;
+    private final String type;
+
+    public static List<NotificationResponse> toList(List<Notification> notifications) {
+        return notifications.stream()
+                .map(NotificationResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    private static NotificationResponse of(Notification notification) {
+        return new NotificationResponse(
+                notification.getId(),
+                AuthorResponse.of(notification.getPublisher()),
+                FeedNotificationResponse.of(notification.getFeed()),
+                notification.getNotificationType().name()
+        );
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/ProfileResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/ProfileResponse.java
@@ -15,10 +15,10 @@ public class ProfileResponse {
     private String nickname;
     private String bio;
     private String imageUrl;
-    private int notifications;
+    private long notifications;
     private LocalDateTime createdAt;
 
-    public static ProfileResponse of(User user, int notifications) {
+    public static ProfileResponse of(User user, long notifications) {
         return new ProfileResponse(user.getId(), user.getNickName(), user.getBio(), user.getImageUrl(),
                 notifications, user.getCreatedDate());
     }

--- a/backend/src/main/resources/db/migration/V6__add_notification.sql
+++ b/backend/src/main/resources/db/migration/V6__add_notification.sql
@@ -1,0 +1,25 @@
+create table `notification` (
+       `id` bigint(20) NOT NULL AUTO_INCREMENT,
+       `created_date` datetime NOT NULL,
+       `modified_date` datetime DEFAULT NULL,
+       `notification_type` varchar(255) NOT NULL,
+        `feed_id` bigint(20) NOT NULL,
+        `listener_id` bigint(20) NOT NULL,
+        `publisher_id` bigint(20) NOT NULL,
+        primary key (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+alter table notification
+       add constraint FKitid6tgnc70scny6gcltfu91u
+       foreign key (feed_id)
+       references feed(id);
+
+alter table notification
+       add constraint FK4qv6svm9lautfkk662sum330a
+       foreign key (listener_id)
+       references user(id);
+
+alter table notification
+       add constraint FKfvmrsnrraov7iy9rpssvvr7nk
+       foreign key (publisher_id)
+       references user(id);

--- a/backend/src/test/java/com/wooteco/nolto/api/MemberControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/MemberControllerTest.java
@@ -41,8 +41,8 @@ class MemberControllerTest extends ControllerTest {
     private static final User LOGIN_USER =
             new User(1L, "11111", SocialType.GOOGLE, "아마찌", "imageUrl", "");
 
-    private static final int NOTIFICATIONS = 0;
-    private static final MemberResponse MEMBER_RESPONSE = MemberResponse.of(LOGIN_USER);
+    private static final long NOTIFICATIONS = 0L;
+    private static final MemberResponse MEMBER_RESPONSE = MemberResponse.of(LOGIN_USER, NOTIFICATIONS);
     private static final NicknameValidationResponse NICKNAME_VALIDATION_RESPONSE = new NicknameValidationResponse(true);
     private static final MockMultipartFile MOCK_MULTIPART_FILE =
             new MockMultipartFile("thumbnailImage", "thumbnailImage.png", "image/png", "<<png data>>".getBytes());
@@ -70,6 +70,7 @@ class MemberControllerTest extends ControllerTest {
     @Test
     void findMemberOfMine() throws Exception {
         given(authService.findUserByToken(ACCESS_TOKEN)).willReturn(LOGIN_USER);
+        given(memberService.findMemberOfMine(LOGIN_USER)).willReturn(MEMBER_RESPONSE);
 
         mockMvc.perform(
                 get("/members/me")

--- a/backend/src/test/java/com/wooteco/nolto/api/TechControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/TechControllerTest.java
@@ -36,6 +36,10 @@ class TechControllerTest extends ControllerTest {
     public static final List<TechResponse> TECH_RESPONSES2 = Arrays.asList(
             new TechResponse(67L, "Spring"), new TechResponse(1149L, "Java"));
 
+    public static final List<TechResponse> TREND_TECH_RESPONSES = Arrays.asList(
+            new TechResponse(67L, "Spring"), new TechResponse(1149L, "Java"),
+            new TechResponse(67L, "Spring"), new TechResponse(1149L, "Java"));
+
     @MockBean
     private TechService techService;
 
@@ -74,6 +78,22 @@ class TechControllerTest extends ControllerTest {
                         requestParameters(
                                 parameterWithName("names").description("기술 이름")
                         ),
+                        responseFields(
+                                fieldWithPath("[]").type(JsonFieldType.ARRAY).description("기술 스택 목록"))
+                                .andWithPrefix("[].", TECH)));
+    }
+
+    @DisplayName("최신 트랜드 기술을 4개만 조회한다.")
+    @Test
+    void findTrendTechs() throws Exception {
+        given(techService.findTrendTechs()).willReturn(TREND_TECH_RESPONSES);
+
+        mockMvc.perform(get("/tags/techs/trend"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(TREND_TECH_RESPONSES)))
+                .andDo(document("tech-findTrendTechs",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
                         responseFields(
                                 fieldWithPath("[]").type(JsonFieldType.ARRAY).description("기술 스택 목록"))
                                 .andWithPrefix("[].", TECH)));


### PR DESCRIPTION
## 작업 내용

-  Notification 이벤트 리스너 구현
  - Entity, Repository 구현
  - 이벤트 객체 구현
  - 이벤트 핸들러 구현

- Async와 TransactionEventListener를 통해 NotificationEventHandler 구현
  - 하나의 쓰레드는 하나의 트랜잭션만을 가지지 않을까하여 작성

- 최신 기술 조회 테스트 코드 작성
- 댓글 등록/수정 시 알림 기능 구현
- 알림 조회 기능 구현
- 알림 단일 삭제/일괄 삭제 구현
- 알림 조회 시 최신순 정렬
- 로그인 유저의 알림 필드 추가
- notification 테이블 추가한 sql문 추가

Closes #테크API명세 and #댓글알림기능

## 주의사항

- 나도 여자 배구 보고 싶어

