### PR TITLE
refactor(comment): 댓글 삭제시 모든 연관관계를 끊어주도록 수정

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/CommentLike.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/CommentLike.java
@@ -38,6 +38,12 @@ public class CommentLike {
         return this.user.sameAs(user);
     }
 
+    public void deleteByCommit(Comment comment) {
+        if (this.comment.equals(comment)) {
+            this.comment = null;
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
@@ -60,7 +60,7 @@ public class Feed extends BaseEntity {
     @OneToMany(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FeedTech> feedTechs = new ArrayList<>();
 
-    @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
     public Feed(String title, String content, Step step, boolean isSos, String storageUrl, String deployedUrl, String thumbnailUrl) {

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -53,10 +53,10 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private final List<Like> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<CommentLike> commentLikes = new ArrayList<>();
 
     public User(Long id, String socialId, SocialType socialType, String nickName) {
@@ -143,10 +143,7 @@ public class User extends BaseEntity {
 
     public void deleteComment(Comment comment) {
         this.comments.remove(comment);
-        comment.getFeed().deleteComment(comment);
-        if (comment.isReply()) {
-            comment.getParentComment().removeReply(comment);
-        }
+        comment.delete();
     }
 
     @Override

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
@@ -297,6 +297,43 @@ class CommentServiceTest extends CommentServiceFixture {
         assertThat(삭제후_조회한_아마찌의_개쩌는_지하철_미션.getComments().size()).isOne();
     }
 
+    @DisplayName("댓글 작성자가 대댓글이 존재하는 댓글을 삭제한다.")
+    @Test
+    void deleteCommentExistReply() {
+        // given
+        Comment 포모_댓글 = 댓글_생성("영 차 영 차 영 차 영 차 영 차 영 차", false, 포모1, 아마찌의_개쩌는_지하철_미션);
+        Comment 아마찌_대댓글 = 댓글_생성("영 차 영 차 영 차", false, 아마찌, 아마찌의_개쩌는_지하철_미션);
+        아마찌_대댓글.addParentComment(포모_댓글);
+        commentRepository.save(포모_댓글);
+        commentRepository.save(아마찌_대댓글);
+        Long 포모_댓글_ID = 포모_댓글.getId();
+        Long 아마찌_대댓글_ID = 아마찌_대댓글.getId();
+        entityManager.clear();
+
+        // when
+        assertThat(포모1.getComments().size()).isOne();
+        assertThat(아마찌.getComments().size()).isOne();
+        User 조회한_포모2 = userRepository.findById(포모1.getId()).get();
+        commentService.deleteComment(조회한_포모2, 포모_댓글.getId());
+        entityManager.flush();
+        entityManager.clear();
+        Feed 삭제후_조회한_아마찌의_개쩌는_지하철_미션 = feedRepository.findById(아마찌의_개쩌는_지하철_미션.getId()).get();
+        User 조회한_포모1 = userRepository.findById(포모1.getId()).get();
+        User 조회한_아마찌 = userRepository.findById(아마찌.getId()).get();
+
+
+        // then
+        assertThatThrownBy(() -> commentService.findEntityById(포모_댓글_ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 댓글입니다.");
+        assertThatThrownBy(() -> commentService.findEntityById(아마찌_대댓글_ID))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("존재하지 않는 댓글입니다.");
+        assertThat(조회한_포모1.getComments().size()).isZero();
+        assertThat(조회한_아마찌.getComments().size()).isZero();
+        assertThat(삭제후_조회한_아마찌의_개쩌는_지하철_미션.getComments().size()).isZero();
+    }
+
     private Comment 댓글_생성(String 댓글_내용, boolean 도움, User 댓글_유저, Feed 피드) {
         Comment 댓글 = new Comment(댓글_내용, 도움).writtenBy(댓글_유저, 피드);
         return 댓글;


### PR DESCRIPTION
## 작업 내용
엄청난 연관관계와의 싸움..
- 댓글 삭제 시 대댓글이 자동으로 지워지기 위해 해야하는 관계 끊기 작업
    - 댓글을 작성한 유저와의 관계
    - 댓글이 속한 피드와의 관계
    - 댓글에 있는 모든 좋아요와의 관계
    - 댓글에 속한 대댓글들 또한 위의 관계를 모두 끊어줘야함

Closes #385 

## 스크린샷
![image](https://user-images.githubusercontent.com/57378410/128606965-60faaa7a-3776-4dad-8917-b681820c961e.png)


## 주의사항
앞으로 연관관계와의 전쟁을 해야할지도..