### PR TITLE
fix: 댓글 좋아요순 -> 최신순으로 변경

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
@@ -36,7 +36,8 @@ public class CommentService {
     }
 
     public List<CommentWithReplyResponse> findAllByFeedId(Long feedId, User user) {
-        List<Comment> comments = commentRepository.findAllByFeedId(feedId);
+        List<Comment> comments = commentRepository.findAllByFeedIdAndParentCommentIdIsNull(feedId);
+        comments.sort(Comparator.comparing(Comment::getCreatedDate, Comparator.reverseOrder()));
         return CommentWithReplyResponse.toList(comments, user);
     }
 

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/CommentRepository.java
@@ -13,7 +13,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "from Comment as com " +
             "where com.feed.id = :feedId and com.parentComment.id is null " +
             "order by com.likes.size desc , com.createdDate desc")
-    List<Comment> findAllByFeedId(@Param("feedId") Long feedId);
+    List<Comment> findAllByFeedIdOrderByLike(@Param("feedId") Long feedId);
+
+    List<Comment> findAllByFeedIdAndParentCommentIdIsNull(Long feedId);
 
     List<Comment> findAllByFeedIdAndParentCommentId(Long feedId, Long parentCommentId);
 

--- a/backend/src/test/java/com/wooteco/nolto/acceptance/CommentAcceptanceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/acceptance/CommentAcceptanceTest.java
@@ -132,7 +132,7 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 로그인_하지않고_댓글_목록_조회한다(업로드한_피드의_ID);
 
         // then
-        댓글_목록_조회_성공(response, 2, commentResponse1, commentResponse2);
+        댓글_목록_조회_성공(response, 2, commentResponse2, commentResponse1);
     }
 
     @DisplayName("로그인한 유저가 이미 좋아요를 누른 댓글을 조회시 liked가 true다")
@@ -151,7 +151,7 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 로그인_하고_댓글_목록_조회한다(로그인된_댓글_작성자의_토큰.getAccessToken(), 업로드한_피드의_ID);
 
         // then
-        댓글_목록_조회시_이미_좋아요누른_댓글은_좋아요를_누른것으로_표시된다(response, 2, commentResponse1);
+        댓글_목록_조회시_이미_좋아요누른_댓글은_좋아요를_누른것으로_표시된다(response, 2, commentResponse1, 1);
     }
 
     @DisplayName("댓글 작성자가 자신의 댓글(또는 대댓글)을 수정한다.")
@@ -501,12 +501,12 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         assertThat(commentResponses[1].getId()).isEqualTo(secondComment.getId());
     }
 
-    private void 댓글_목록_조회시_이미_좋아요누른_댓글은_좋아요를_누른것으로_표시된다(ExtractableResponse<Response> response, int commentCount, CommentResponse commentResponse) {
+    private void 댓글_목록_조회시_이미_좋아요누른_댓글은_좋아요를_누른것으로_표시된다(ExtractableResponse<Response> response, int commentCount, CommentResponse commentResponse, int order) {
         CommentResponse[] commentResponses = response.as(CommentResponse[].class);
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(commentResponses).hasSize(commentCount);
-        CommentResponse 이미_좋아요_누른_댓글 = commentResponses[0];
+        CommentResponse 이미_좋아요_누른_댓글 = commentResponses[order];
         assertThat(이미_좋아요_누른_댓글.getId()).isEqualTo(commentResponse.getId());
         assertThat(이미_좋아요_누른_댓글.isLiked()).isTrue();
     }

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceFixture.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceFixture.java
@@ -51,7 +51,7 @@ public class CommentServiceFixture {
     }
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws InterruptedException {
         찰리 = new User("SOCIAL_ID", SocialType.GITHUB, "찰리", "IMAGE");
         포모 = new User("SOCIAL_ID2", SocialType.GITHUB, "포모", "IMAGE2");
         userRepository.saveAndFlush(찰리);
@@ -68,8 +68,10 @@ public class CommentServiceFixture {
         feedRepository.saveAndFlush(찰리가_쓴_피드);
 
         찰리가_쓴_피드에_찰리가_쓴_댓글 = new Comment("첫 댓글", false).writtenBy(찰리, 찰리가_쓴_피드);
+        commentRepository.save(찰리가_쓴_피드에_찰리가_쓴_댓글);
         찰리가_쓴_피드에_포모가_쓴_댓글 = new Comment("두 번째 댓글", true).writtenBy(포모, 찰리가_쓴_피드);
-        commentRepository.saveAllAndFlush(Arrays.asList(찰리가_쓴_피드에_찰리가_쓴_댓글, 찰리가_쓴_피드에_포모가_쓴_댓글));
+        commentRepository.save(찰리가_쓴_피드에_포모가_쓴_댓글);
+        commentRepository.flush();
         찰리가_쓴_피드에_찰리가_쓴_댓글에_찰리가_쓴_대댓글 = new Comment("첫 대댓글", false).writtenBy(찰리, 찰리가_쓴_피드);
         찰리가_쓴_피드에_찰리가_쓴_댓글에_찰리가_쓴_대댓글.addParentComment(찰리가_쓴_피드에_찰리가_쓴_댓글);
         찰리가_쓴_피드에_찰리가_쓴_댓글에_포모가_쓴_대댓글 = new Comment("두 번째 대댓글", false).writtenBy(포모, 찰리가_쓴_피드);

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
@@ -14,6 +14,7 @@ import com.wooteco.nolto.feed.ui.dto.ReplyResponse;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,7 +51,7 @@ class CommentServiceTest extends CommentServiceFixture {
     );
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws InterruptedException {
         super.setUp();
         userRepository.save(찰리1);
         userRepository.save(아마찌);
@@ -84,6 +85,7 @@ class CommentServiceTest extends CommentServiceFixture {
         assertThat(response.getCreatedAt()).isNotNull();
     }
 
+    @Disabled
     @DisplayName("특정 피드에 대한 댓글과 대댓글 전체를 조회한다. 댓글은 좋아요 + 최신 순, 대댓글은 최신 순 정렬")
     @Test
     void findAllByFeedId() {
@@ -99,6 +101,19 @@ class CommentServiceTest extends CommentServiceFixture {
         // then
         checkSameCommentWithReplyResponse(allByFeedId.get(0), 찰리가_쓴_피드에_찰리가_쓴_댓글, 찰리);
         checkSameCommentWithReplyResponse(allByFeedId.get(1), 찰리가_쓴_피드에_포모가_쓴_댓글, 찰리);
+    }
+
+    @DisplayName("특정 피드에 대한 댓글과 대댓글 전체를 조회한다. 댓글, 대댓글은 최신 순 정렬")
+    @Test
+    void findAllByFeedId2() {
+        // when
+        commentLikeService.addCommentLike(찰리가_쓴_피드에_찰리가_쓴_댓글.getId(), 찰리);
+
+        List<CommentWithReplyResponse> allByFeedId = commentService.findAllByFeedId(찰리가_쓴_피드.getId(), 찰리);
+
+        // then
+        checkSameCommentWithReplyResponse(allByFeedId.get(0), 찰리가_쓴_피드에_포모가_쓴_댓글, 찰리);
+        checkSameCommentWithReplyResponse(allByFeedId.get(1), 찰리가_쓴_피드에_찰리가_쓴_댓글, 찰리);
     }
 
     @DisplayName("댓글을 수정할 수 있다.")


### PR DESCRIPTION
## 작업 내용

- 댓글 좋아요순 -> 최신순으로 변경
- 기존의 좋아요순 댓글 조회 메서드 네이밍 변경 `findAllByFeedIdOrderByLike
