### PR TITLE
fix: fixture thread sleep 추가

### DIFF
--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceFixture.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceFixture.java
@@ -69,6 +69,7 @@ public class CommentServiceFixture {
 
         찰리가_쓴_피드에_찰리가_쓴_댓글 = new Comment("첫 댓글", false).writtenBy(찰리, 찰리가_쓴_피드);
         commentRepository.save(찰리가_쓴_피드에_찰리가_쓴_댓글);
+        Thread.sleep(1);
         찰리가_쓴_피드에_포모가_쓴_댓글 = new Comment("두 번째 댓글", true).writtenBy(포모, 찰리가_쓴_피드);
         commentRepository.save(찰리가_쓴_피드에_포모가_쓴_댓글);
         commentRepository.flush();


### PR DESCRIPTION
## 작업 내용

- 댓글 저장 시 createdAt이 완전히 똑같아 테스트가 안되는 경우 방지
- fix: fixture thread sleep 추가

## 스크린샷


## 주의사항

- 바쁘다 바뻐 
