### PR TITLE
refactor: 알림에 대한 본인 검증 로직 구현

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEvent.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEvent.java
@@ -32,4 +32,8 @@ public class NotificationEvent {
     public static NotificationEvent likeOf(Feed feed, User publisher) {
         return new NotificationEvent(feed.getAuthor(), feed, null, publisher, NotificationType.LIKE);
     }
+
+    public boolean validatePublisher() {
+        return !publisher.sameAs(listener);
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
@@ -5,8 +5,6 @@ import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.exception.NotFoundException;
 import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.feed.domain.Feed;
-import com.wooteco.nolto.feed.domain.repository.CommentRepository;
-import com.wooteco.nolto.feed.domain.repository.FeedRepository;
 import com.wooteco.nolto.notification.domain.Notification;
 import com.wooteco.nolto.notification.domain.NotificationRepository;
 import com.wooteco.nolto.user.domain.User;
@@ -27,7 +25,9 @@ public class NotificationService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void save(NotificationEvent notificationEvent) {
         Notification notification = notificationEvent.toEntity();
-        notificationRepository.save(notification);
+        if (notificationEvent.validatePublisher()) {
+            notificationRepository.save(notification);
+        }
     }
 
     public List<Notification> findAllByUser(User user) {

--- a/backend/src/test/java/com/wooteco/nolto/acceptance/UserAcceptanceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/acceptance/UserAcceptanceTest.java
@@ -108,7 +108,7 @@ public class UserAcceptanceTest extends AcceptanceTest {
         assertThat(닉네임_사용_불가능_응답.isIsUsable()).isFalse();
     }
 
-    @DisplayName("멤버가 자신의 프로필을 조회한다.")
+    @DisplayName("멤버가 자신의 프로필을 조회한다. 자신이 좋아요를 누른 경우 알림 X")
     @Test
     void findProfileOfMine() {
         // given
@@ -120,7 +120,7 @@ public class UserAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 프로필_조회_요청(token);
 
         // then
-        프로필_조회_응답됨(response, 엄청난_유저, 1);
+        프로필_조회_응답됨(response, 엄청난_유저, 0);
     }
 
     @DisplayName("멤버가 자신의 프로필을 수정한다.")

--- a/backend/src/test/java/com/wooteco/nolto/notification/application/NotificationEventTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/notification/application/NotificationEventTest.java
@@ -67,7 +67,7 @@ public class NotificationEventTest {
         feedRepository.save(찰리가_쓴_피드);
     }
 
-    @DisplayName("피드에 좋아요를 받은 경우 알림을 저장한다.")
+    @DisplayName("피드에 좋아요를 받은 경우 알림을 저장한다.(본인 유무는 이벤트 발생과 무관)")
     @Test
     void saveWhenFeedLike() {
         NotificationEvent 피드_좋아요_이벤트 = NotificationEvent.likeOf(찰리가_쓴_피드, 포모);


### PR DESCRIPTION
## 작업 내용

- 본인의 피드 좋아요, 댓글 등록, 대댓글 등록에 대한 알림은 발행하지 않도록 변경
- 인수테스트에서 자신의 피드를 좋아요 하고 알림 조회하는 경우 카운트가 올라가지 않도록 변경
- Closes #425

