### PR TITLE
fix(reply): 대댓글 작성자와 피드 작성자가 일치할 때 isFeedAuthor 가 false 로 응답하는 버그 수정

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
@@ -16,7 +16,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Comparator;
 import java.util.List;
 
 @Transactional
@@ -38,7 +37,6 @@ public class CommentService {
 
     public List<CommentResponse> findAllByFeedId(Long feedId, User user) {
         List<Comment> comments = commentRepository.findAllByFeedIdAndParentCommentIdIsNull(feedId);
-        comments.sort(Comparator.comparing(Comment::getCreatedDate, Comparator.reverseOrder()));
         return CommentResponse.toList(comments, user);
     }
 
@@ -85,8 +83,7 @@ public class CommentService {
     }
 
     public List<ReplyResponse> findAllRepliesById(User user, Long feedId, Long commentId) {
-        List<Comment> replies = commentRepository.findAllByFeedIdAndParentCommentId(feedId, commentId);
-        replies.sort(Comparator.comparing(Comment::getCreatedDate, Comparator.reverseOrder()));
+        List<Comment> replies = commentRepository.findAllByFeedIdAndParentCommentIdWithFetchJoin(feedId, commentId);
         return ReplyResponse.toList(replies, user);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/CommentRepository.java
@@ -24,9 +24,15 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "join fetch com.feed " +
             "where com.feed.id = :feedId and com.parentComment.id is null " +
             "order by com.createdDate desc")
-    List<Comment> findAllByFeedIdAndParentCommentIdIsNull(Long feedId);
+    List<Comment> findAllByFeedIdAndParentCommentIdIsNull(@Param("feedId") Long feedId);
 
-    List<Comment> findAllByFeedIdAndParentCommentId(Long feedId, Long parentCommentId);
+    @Query(value = "select com " +
+            "from Comment as com " +
+            "join fetch com.author " +
+            "join fetch com.feed " +
+            "where com.feed.id = :feedId and com.parentComment.id = :parentCommentId " +
+            "order by com.createdDate desc")
+    List<Comment> findAllByFeedIdAndParentCommentIdWithFetchJoin(@Param("feedId") Long feedId, @Param("parentCommentId") Long parentCommentId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = "delete from Comment c where c.id = :commentId or c.parentComment.id = :commentId")

--- a/backend/src/test/java/com/wooteco/nolto/acceptance/CommentAcceptanceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/acceptance/CommentAcceptanceTest.java
@@ -639,11 +639,11 @@ public class CommentAcceptanceTest extends AcceptanceTest {
         assertThat(commentResponses).hasSize(replyCount);
         assertThat(commentResponses[0].getId()).isEqualTo(firstReply.getId());
         assertThat(commentResponses[0].isLiked()).isFalse();
-        assertThat(commentResponses[0].isFeedAuthor()).isFalse();
+        assertThat(commentResponses[0].isFeedAuthor()).isTrue();
 
         assertThat(commentResponses[1].getId()).isEqualTo(secondReply.getId());
         assertThat(commentResponses[1].isLiked()).isFalse();
-        assertThat(commentResponses[1].isFeedAuthor()).isFalse();
+        assertThat(commentResponses[1].isFeedAuthor()).isTrue();
     }
 
     private void 로그인_하고_대댓글_목록_조회_성공(ExtractableResponse<Response> response, int replyCount, CommentResponse firstReply, CommentResponse secondReply) {


### PR DESCRIPTION
## 작업 내용
대댓글 조회 시 JPQL 추가
```java
@Query(value = "select com " +
            "from Comment as com " +
            "join fetch com.author " +
            "join fetch com.feed " +
            "where com.feed.id = :feedId and com.parentComment.id = :parentCommentId " +
            "order by com.createdDate desc")
    List<Comment> findAllByFeedIdAndParentCommentIdWithFetchJoin(@Param("feedId") Long feedId, @Param("parentCommentId") Long parentCommentId);
```


Closes #428
