### PR TITLE
fix(MemberServiceTest): 생성 시 User/Feed/Comment/Like 연관관계 제거

### DIFF
--- a/backend/src/test/java/com/wooteco/nolto/user/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/user/application/MemberServiceTest.java
@@ -63,61 +63,51 @@ class MemberServiceTest {
     public static final ProfileRequest 프로필_수정_요청 = new ProfileRequest(수정할_닉네임, "안녕하세용", null);
     public static final ProfileRequest 존재하는_닉네임으로_프로필_수정_요청 = new ProfileRequest(존재하는_백신_영상_닉네임, "안녕하세용", null);
 
-    private final User 존재하는_백신_영상이 = new User(null, "1", SocialType.GITHUB, 존재하는_백신_영상_닉네임, "joel.jpg");
-    private final User 존재하는_아마찌 = new User(null, "2", SocialType.GITHUB, "AMAZZI", "ama.jpg");
+    private final User 영상이 = new User(null, "1", SocialType.GITHUB, 존재하는_백신_영상_닉네임, "joel.jpg");
+    private final User 아마찌 = new User(null, "2", SocialType.GITHUB, "AMAZZI", "ama.jpg");
 
-    private final Feed 영상이_피드 = new Feed("joelFeed", "joelFeed", Step.PROGRESS, true, "", "", "").writtenBy(존재하는_백신_영상이);
-    private final Feed 아마찌_피드 = new Feed("amaFeed", "amaFeed", Step.PROGRESS, true, "", "", "").writtenBy(존재하는_아마찌);
+    private final Feed 영상이_피드 = new Feed("joelFeed", "joelFeed", Step.PROGRESS, true, "", "", "");
+    private final Feed 아마찌_피드 = new Feed("amaFeed", "amaFeed", Step.PROGRESS, true, "", "", "");
 
-    private Comment 영상이_피드에_영상이_댓글 = new Comment("joelCommentJoelFeed", true).writtenBy(존재하는_백신_영상이, 영상이_피드);
-    private Comment 영상이_피드에_아마찌_댓글 = new Comment("joelCommentAmaFeed", true).writtenBy(존재하는_백신_영상이, 영상이_피드);
+    private final Comment 영상이_피드에_영상이_댓글 = new Comment("joelFeedJoelComment", true);
+    private final Comment 아마찌_피드에_영상이_댓글 = new Comment("amaFeedJoelComment", true);
 
-    private final Like 영상이_좋아요_영상이_피드 = new Like(존재하는_백신_영상이, 영상이_피드);
-    private final Like 영상이_좋아요_아마찌_피드 = new Like(존재하는_백신_영상이, 아마찌_피드);
+    private final Like 영상이_피드에_영상이_좋아요 = new Like(영상이, 영상이_피드);
+    private final Like 아마찌_피드에_영상이_좋아요 = new Like(영상이, 아마찌_피드);
 
     @BeforeEach
-    void setUp() throws InterruptedException {
+    void setUp() {
         given(imageService.upload(any(MultipartFile.class), any(ImageKind.class))).willReturn("image.jpg");
-        userRepository.saveAndFlush(존재하는_백신_영상이);
-        Thread.sleep(1);
-        userRepository.saveAndFlush(존재하는_아마찌);
-        Thread.sleep(1);
+        userRepository.saveAndFlush(영상이);
+        userRepository.saveAndFlush(아마찌);
 
-        feedRepository.saveAndFlush(영상이_피드);
-        Thread.sleep(1);
-        feedRepository.saveAndFlush(아마찌_피드);
-        Thread.sleep(1);
+        feedRepository.saveAndFlush(영상이_피드.writtenBy(영상이));
+        feedRepository.saveAndFlush(아마찌_피드.writtenBy(아마찌));
 
-        영상이_피드.addComment(영상이_피드에_영상이_댓글);
-        commentRepository.saveAndFlush(영상이_피드에_영상이_댓글);
-        Thread.sleep(1);
-        아마찌_피드.addComment(영상이_피드에_아마찌_댓글);
-        commentRepository.saveAndFlush(영상이_피드에_아마찌_댓글);
-        Thread.sleep(1);
+        commentRepository.saveAndFlush(영상이_피드에_영상이_댓글.writtenBy(영상이, 영상이_피드));
+        commentRepository.saveAndFlush(아마찌_피드에_영상이_댓글.writtenBy(영상이, 아마찌_피드));
 
-        존재하는_백신_영상이.addLike(영상이_좋아요_영상이_피드);
-        likeRepository.saveAndFlush(영상이_좋아요_영상이_피드);
-        Thread.sleep(1);
-        존재하는_백신_영상이.addLike(영상이_좋아요_아마찌_피드);
-        likeRepository.saveAndFlush(영상이_좋아요_아마찌_피드);
-        Thread.sleep(1);
+        영상이.addLike(영상이_피드에_영상이_좋아요);
+        likeRepository.saveAndFlush(영상이_피드에_영상이_좋아요);
+        영상이.addLike(아마찌_피드에_영상이_좋아요);
+        likeRepository.saveAndFlush(아마찌_피드에_영상이_좋아요);
     }
 
     @DisplayName("사용자의 히스토리(좋아요 한 글, 내가 작성한 글, 내가 남긴 댓글)를 최신순으로 조회할 수 있다.")
     @Test
     void findHistory() {
         //when
-        MemberHistoryResponse memberHistoryResponse = memberService.findHistory(존재하는_백신_영상이);
+        MemberHistoryResponse memberHistoryResponse = memberService.findHistory(영상이);
 
         //then
         List<String> likedFeedsTitle = getFeedHistoryResponseTitle(memberHistoryResponse.getLikedFeeds());
-        assertThat(likedFeedsTitle).contains(아마찌_피드.getTitle(), 영상이_피드.getTitle());
+        assertThat(likedFeedsTitle).containsExactly(아마찌_피드.getTitle(), 영상이_피드.getTitle());
 
         List<String> myFeedsTitle = getFeedHistoryResponseTitle(memberHistoryResponse.getMyFeeds());
         assertThat(myFeedsTitle).contains(영상이_피드.getTitle());
 
         List<String> myComments = getCommentResponseComment(memberHistoryResponse.getMyComments());
-        assertThat(myComments).contains(영상이_피드에_아마찌_댓글.getContent(), 영상이_피드에_영상이_댓글.getContent());
+        assertThat(myComments).containsExactly(아마찌_피드에_영상이_댓글.getContent(), 영상이_피드에_영상이_댓글.getContent());
     }
 
     @DisplayName("닉네임의 중복 여부를 검사한다.")
@@ -135,15 +125,15 @@ class MemberServiceTest {
     @DisplayName("멤버의 프로필을 조회한다.")
     @Test
     void findProfile() {
-        ProfileResponse 프로필_조회_응답 = memberService.findProfile(존재하는_백신_영상이);
+        ProfileResponse 프로필_조회_응답 = memberService.findProfile(영상이);
 
-        멤버_프로필_정보가_같은지_확인(존재하는_백신_영상이, 프로필_조회_응답);
+        멤버_프로필_정보가_같은지_확인(영상이, 프로필_조회_응답);
     }
 
     @DisplayName("멤버의 프로필을 수정한다.")
     @Test
     void updateProfile() {
-        ProfileResponse 프로필_수정_응답 = memberService.updateProfile(존재하는_백신_영상이, 프로필_수정_요청);
+        ProfileResponse 프로필_수정_응답 = memberService.updateProfile(영상이, 프로필_수정_요청);
 
         멤버_프로필_정보가_같은지_확인(프로필_수정_요청, 프로필_수정_응답);
     }
@@ -151,7 +141,7 @@ class MemberServiceTest {
     @DisplayName("멤버의 프로필을 수정하는 경우 자신의 기존 닉네임과 동일하면 정상으로 동작한다.")
     @Test
     void updateProfileException() {
-        ProfileResponse 프로필_수정_응답 = memberService.updateProfile(존재하는_백신_영상이, 존재하는_닉네임으로_프로필_수정_요청);
+        ProfileResponse 프로필_수정_응답 = memberService.updateProfile(영상이, 존재하는_닉네임으로_프로필_수정_요청);
 
         멤버_프로필_정보가_같은지_확인(존재하는_닉네임으로_프로필_수정_요청, 프로필_수정_응답);
     }
@@ -159,7 +149,7 @@ class MemberServiceTest {
     @DisplayName("멤버의 프로필을 수정하는 경우 이미 존재하는 닉네임일 경우 예외가 발생한다.")
     @Test
     void updateProfileNotException() {
-        assertThatThrownBy(() -> memberService.updateProfile(존재하는_아마찌, 존재하는_닉네임으로_프로필_수정_요청))
+        assertThatThrownBy(() -> memberService.updateProfile(아마찌, 존재하는_닉네임으로_프로필_수정_요청))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorType.ALREADY_EXIST_NICKNAME.getMessage());
     }


### PR DESCRIPTION
## 작업 내용
- fix(MemberServiceTest): 생성 시 User/Feed/Comment/Like 연관관계 제거

## 주의사항
- 네이밍이 잘못되어 있어서 수정했습니다
- 이제 진짜 제발 안터질거에요,,, 😅