### PR TITLE
[FE] 2차 UT 이것저것 수정

### DIFF
--- a/frontend/src/components/@common/Avatar/Avatar.tsx
+++ b/frontend/src/components/@common/Avatar/Avatar.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import { User } from 'types';
+import { Author } from 'types';
 import Styled from './Avatar.styles';
 
 interface Props {
-  user: User;
+  user: Author;
   className?: string;
 }
 

--- a/frontend/src/components/FeedUploadForm/FeedUploadForm.styles.ts
+++ b/frontend/src/components/FeedUploadForm/FeedUploadForm.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 import TextArea from 'components/@common/TextArea/TextArea';
 import TextButton from 'components/@common/TextButton/TextButton';
@@ -90,11 +90,23 @@ const ButtonsWrapper = styled.div`
 
 const QuestionMark = styled.span``;
 
+const show = keyframes`
+  from {
+    opacity: 0;
+  }
+  
+  to {
+    opacity: 1;
+  }
+`;
+
 export const LevelTooltip = styled(Tooltip)<{ visible: boolean }>`
   display: ${({ visible }) => !visible && 'none'};
   position: absolute;
   top: 10%;
   left: 70%;
+
+  animation: ${show} 0.2s ease;
 `;
 
 export const SOSTooltip = styled(Tooltip)<{ visible: boolean }>`
@@ -102,6 +114,8 @@ export const SOSTooltip = styled(Tooltip)<{ visible: boolean }>`
   position: absolute;
   top: 15%;
   right: 105%;
+
+  animation: ${show} 0.2s ease;
 `;
 
 const InputCaption = styled.span`

--- a/frontend/src/components/FeedUploadForm/FeedUploadForm.tsx
+++ b/frontend/src/components/FeedUploadForm/FeedUploadForm.tsx
@@ -138,7 +138,7 @@ const FeedUploadForm = ({ onFeedSubmit, initialFormValue }: Props) => {
                 <pre>
                   <strong>프로젝트 단계</strong> <br />
                   <br />
-                  🎈조립중: 프로젝트가 완성되지 않았어요 <br />
+                  🧩 조립중: 프로젝트가 완성되지 않았어요 <br />
                   🦄 전시중: 프로젝트가 완성됐어요
                 </pre>
               </LevelTooltip>

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -61,7 +61,7 @@ const Header = ({ isFolded = false }: Props) => {
           <Styled.NavContainer>
             <li>
               <NavLink to={ROUTE.RECENT} activeStyle={navLinkActiveStyle}>
-                Feeds
+                Toy Projects
               </NavLink>
             </li>
             <li>

--- a/frontend/src/components/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/SearchBar/SearchBar.tsx
@@ -23,6 +23,16 @@ const SearchBar = ({ className, selectable = false, ...options }: Props) => {
   const search = (event: React.FormEvent) => {
     event.preventDefault();
 
+    // 아무것도 검색하지 않았을 때
+    if (
+      (searchType === SearchType.CONTENT && query === '') ||
+      (searchType === SearchType.TECH && techs.length === 0)
+    ) {
+      history.push(ROUTE.RECENT);
+
+      return;
+    }
+
     const queryParams = new URLSearchParams({
       query,
       techs: techs.map((tech) => tech.text).join(','),

--- a/frontend/src/components/TrendTechs/TrendTechs.styles.ts
+++ b/frontend/src/components/TrendTechs/TrendTechs.styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { PALETTE } from 'constants/palette';
+import { hoverUnderline } from 'commonStyles';
 
 const Root = styled.div`
   display: flex;
@@ -21,9 +22,7 @@ const Tag = styled.span`
   cursor: pointer;
 
   > .trends-text {
-    &:hover {
-      text-decoration: underline;
-    }
+    ${hoverUnderline};
   }
 
   > .trends-bar {

--- a/frontend/src/components/UserProfile/UserProfile.styles.ts
+++ b/frontend/src/components/UserProfile/UserProfile.styles.ts
@@ -62,6 +62,7 @@ const Dropdown = styled.div<{ isOpen: boolean }>`
   display: ${({ isOpen }) => (isOpen ? 'flex' : 'none')};
   position: absolute;
   width: fit-content;
+  min-width: 6.5rem;
   max-width: 8rem;
   top: 120%;
   flex-direction: column;

--- a/frontend/src/components/UserProfile/UserProfile.styles.ts
+++ b/frontend/src/components/UserProfile/UserProfile.styles.ts
@@ -78,6 +78,7 @@ const Dropdown = styled.div<{ isOpen: boolean }>`
 `;
 
 const Greeting = styled.div`
+  width: 100%;
   background-color: ${PALETTE.PRIMARY_400};
   color: ${PALETTE.WHITE_400};
 `;

--- a/frontend/src/hooks/queries/profile/useNicknameCheck.ts
+++ b/frontend/src/hooks/queries/profile/useNicknameCheck.ts
@@ -1,11 +1,11 @@
 import { useQuery, UseQueryOptions } from 'react-query';
 
 import api from 'constants/api';
-import { ErrorHandler, Tech } from 'types';
+import { ErrorHandler } from 'types';
 import HttpError from 'utils/HttpError';
 import { resolveHttpError } from 'utils/error';
 
-interface CustomQueryOption extends UseQueryOptions<Tech[], HttpError> {
+interface CustomQueryOption extends UseQueryOptions<{ isUsable: boolean }, HttpError> {
   nickname: string;
   errorHandler?: ErrorHandler;
 }

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -45,7 +45,7 @@ const Home = () => {
         </Styled.SearchContainer>
 
         <Styled.ContentArea>
-          <Styled.SectionTitle fontSize="1.75rem">Hot Toys</Styled.SectionTitle>
+          <Styled.SectionTitle fontSize="1.75rem">Hot Toy Project</Styled.SectionTitle>
           <Styled.HotToysContainer>
             <AsyncBoundary
               rejectedFallback={
@@ -56,7 +56,7 @@ const Home = () => {
             </AsyncBoundary>
           </Styled.HotToysContainer>
 
-          <Styled.SectionTitle fontSize="1.75rem">Recent Toys</Styled.SectionTitle>
+          <Styled.SectionTitle fontSize="1.75rem">Recent Toy Project</Styled.SectionTitle>
           <Styled.RecentToysContainer>
             <AsyncBoundary
               rejectedFallback={

--- a/frontend/src/pages/Mypage/History/History.styles.ts
+++ b/frontend/src/pages/Mypage/History/History.styles.ts
@@ -27,9 +27,9 @@ const SlideBar = styled.div`
 `;
 
 const highlightPixels = {
-  [UserHistoryType.MY_LIKED]: '0rem',
-  [UserHistoryType.MY_FEED]: '9rem',
-  [UserHistoryType.MY_COMMENT]: '18rem',
+  [UserHistoryType.MY_FEED]: '0rem',
+  [UserHistoryType.MY_COMMENT]: '9rem',
+  [UserHistoryType.MY_LIKED]: '18rem',
 };
 
 const SlideHighlight = styled.span<{ tab: UserHistoryType }>`

--- a/frontend/src/pages/Mypage/History/History.styles.ts
+++ b/frontend/src/pages/Mypage/History/History.styles.ts
@@ -6,7 +6,7 @@ import { hoverLayer } from 'commonStyles';
 
 const Root = styled.div`
   padding: 1rem 2rem;
-  width: 34rem;
+  width: 36rem;
   height: 24rem;
   border-radius: 0.75rem;
   box-shadow: 4px 4px 8px 4px rgba(85, 85, 85, 0.2);
@@ -14,7 +14,7 @@ const Root = styled.div`
 
 const SlideBar = styled.div`
   position: relative;
-  width: 27rem;
+  width: 30rem;
   color: ${PALETTE.ORANGE_400};
   display: flex;
   border-bottom: 1px solid ${PALETTE.ORANGE_400};
@@ -28,12 +28,12 @@ const SlideBar = styled.div`
 
 const highlightPixels = {
   [UserHistoryType.MY_FEED]: '0rem',
-  [UserHistoryType.MY_COMMENT]: '9rem',
-  [UserHistoryType.MY_LIKED]: '18rem',
+  [UserHistoryType.MY_COMMENT]: '10rem',
+  [UserHistoryType.MY_LIKED]: '20rem',
 };
 
 const SlideHighlight = styled.span<{ tab: UserHistoryType }>`
-  width: 9rem;
+  width: 10rem;
   border-bottom: 3px solid ${PALETTE.ORANGE_400};
   position: absolute;
   bottom: 0;
@@ -44,7 +44,7 @@ const SlideHighlight = styled.span<{ tab: UserHistoryType }>`
 const SlideTitle = styled.span<{ selected: boolean }>`
   color: inherit;
   text-align: center;
-  width: 9rem;
+  width: 10rem;
   padding: 0.75rem 1rem;
   font-weight: ${({ selected }) => selected && '700'};
   cursor: pointer;

--- a/frontend/src/pages/Mypage/History/History.tsx
+++ b/frontend/src/pages/Mypage/History/History.tsx
@@ -28,12 +28,14 @@ const History = () => {
 
   const { likedFeeds, myFeeds, myComments } = historyData;
 
+  const idGenerator = genNewId();
+
   useEffect(() => {
     selectedTab.current.scrollIntoView();
   }, [tab]);
 
   const feedWithContent = (feed: Omit<Feed, 'author'>): React.ReactNode => (
-    <Styled.FeedWrapper key={genNewId()} onClick={() => goFeedDetail(feed.id)}>
+    <Styled.FeedWrapper key={idGenerator()} onClick={() => goFeedDetail(feed.id)}>
       <Styled.FeedThumbnail src={feed.thumbnailUrl} />
       <Styled.FeedContentWrapper>
         <Styled.FeedTitle>{feed.title}</Styled.FeedTitle>
@@ -43,7 +45,7 @@ const History = () => {
   );
 
   const feedWithComment = (feed: FeedWithComment): React.ReactNode => (
-    <Styled.FeedWrapper key={genNewId()} onClick={() => goFeedDetail(feed.feed.id)}>
+    <Styled.FeedWrapper key={idGenerator()} onClick={() => goFeedDetail(feed.feed.id)}>
       <Styled.FeedThumbnail src={feed.feed.thumbnailUrl} />
       <Styled.FeedContentWrapper>
         <Styled.FeedTitle>{feed.feed.title}</Styled.FeedTitle>

--- a/frontend/src/pages/Mypage/History/History.tsx
+++ b/frontend/src/pages/Mypage/History/History.tsx
@@ -9,7 +9,7 @@ import { Feed, FeedWithComment, UserHistoryType } from 'types';
 import Styled from './History.styles';
 
 const History = () => {
-  const [tab, setTab] = useState<UserHistoryType>(UserHistoryType.MY_LIKED);
+  const [tab, setTab] = useState<UserHistoryType>(UserHistoryType.MY_FEED);
   const selectedTab = useRef(null);
   const history = useHistory();
 
@@ -65,12 +65,6 @@ const History = () => {
       <Styled.SlideBar id="slide-title">
         <Styled.SlideHighlight tab={tab} />
         <Styled.SlideTitle
-          selected={tab === UserHistoryType.MY_LIKED}
-          onClick={() => setTab(UserHistoryType.MY_LIKED)}
-        >
-          좋아요한 글
-        </Styled.SlideTitle>
-        <Styled.SlideTitle
           selected={tab === UserHistoryType.MY_FEED}
           onClick={() => setTab(UserHistoryType.MY_FEED)}
         >
@@ -82,16 +76,14 @@ const History = () => {
         >
           내가 남긴 댓글
         </Styled.SlideTitle>
+        <Styled.SlideTitle
+          selected={tab === UserHistoryType.MY_LIKED}
+          onClick={() => setTab(UserHistoryType.MY_LIKED)}
+        >
+          좋아요한 글
+        </Styled.SlideTitle>
       </Styled.SlideBar>
       <Styled.FeedsSwipeArea>
-        <Styled.FeedContainer
-          id={UserHistoryType.MY_LIKED}
-          ref={tab === UserHistoryType.MY_LIKED ? selectedTab : null}
-        >
-          {likedFeeds.length > 0
-            ? likedFeeds.map((feed: Omit<Feed, 'author'>) => feedWithContent(feed))
-            : noFeedContent}
-        </Styled.FeedContainer>
         <Styled.FeedContainer
           id={UserHistoryType.MY_FEED}
           ref={tab === UserHistoryType.MY_FEED ? selectedTab : null}
@@ -100,12 +92,22 @@ const History = () => {
             ? myFeeds.map((feed: Omit<Feed, 'author'>) => feedWithContent(feed))
             : noFeedContent}
         </Styled.FeedContainer>
+
         <Styled.FeedContainer
           id={UserHistoryType.MY_COMMENT}
           ref={tab === UserHistoryType.MY_COMMENT ? selectedTab : null}
         >
           {myComments.length > 0
             ? myComments.map((feed: FeedWithComment) => feedWithComment(feed))
+            : noFeedContent}
+        </Styled.FeedContainer>
+
+        <Styled.FeedContainer
+          id={UserHistoryType.MY_LIKED}
+          ref={tab === UserHistoryType.MY_LIKED ? selectedTab : null}
+        >
+          {likedFeeds.length > 0
+            ? likedFeeds.map((feed: Omit<Feed, 'author'>) => feedWithContent(feed))
             : noFeedContent}
         </Styled.FeedContainer>
       </Styled.FeedsSwipeArea>

--- a/frontend/src/pages/Mypage/History/History.tsx
+++ b/frontend/src/pages/Mypage/History/History.tsx
@@ -5,6 +5,7 @@ import useUserHistory from 'hooks/queries/userHistory/useUserHistory';
 import useSnackbar from 'contexts/snackbar/useSnackbar';
 import ROUTE from 'constants/routes';
 import ReturnArrow from 'assets/arrowReturnRight.svg';
+import { genNewId } from 'utils/common';
 import { Feed, FeedWithComment, UserHistoryType } from 'types';
 import Styled from './History.styles';
 
@@ -32,7 +33,7 @@ const History = () => {
   }, [tab]);
 
   const feedWithContent = (feed: Omit<Feed, 'author'>): React.ReactNode => (
-    <Styled.FeedWrapper key={feed.id} onClick={() => goFeedDetail(feed.id)}>
+    <Styled.FeedWrapper key={genNewId()} onClick={() => goFeedDetail(feed.id)}>
       <Styled.FeedThumbnail src={feed.thumbnailUrl} />
       <Styled.FeedContentWrapper>
         <Styled.FeedTitle>{feed.title}</Styled.FeedTitle>
@@ -42,7 +43,7 @@ const History = () => {
   );
 
   const feedWithComment = (feed: FeedWithComment): React.ReactNode => (
-    <Styled.FeedWrapper key={feed.feed.id} onClick={() => goFeedDetail(feed.feed.id)}>
+    <Styled.FeedWrapper key={genNewId()} onClick={() => goFeedDetail(feed.feed.id)}>
       <Styled.FeedThumbnail src={feed.feed.thumbnailUrl} />
       <Styled.FeedContentWrapper>
         <Styled.FeedTitle>{feed.feed.title}</Styled.FeedTitle>

--- a/frontend/src/pages/Mypage/Intro/Intro.styles.ts
+++ b/frontend/src/pages/Mypage/Intro/Intro.styles.ts
@@ -8,7 +8,7 @@ const Root = styled.form`
   align-items: center;
   padding: 1rem 2rem;
   gap: 2rem;
-  width: 34rem;
+  width: 36rem;
   height: 10rem;
   border-radius: 0.75rem;
   box-shadow: 4px 4px 8px 4px rgba(85, 85, 85, 0.2);

--- a/frontend/src/pages/Mypage/Intro/Intro.tsx
+++ b/frontend/src/pages/Mypage/Intro/Intro.tsx
@@ -109,7 +109,7 @@ const Intro = () => {
       };
     }
 
-    if (!nicknameCheck?.isUsable) {
+    if (nicknameCheck?.isUsable === false) {
       return {
         isValid: false,
         message: '이미 사용중인 닉네임입니다.',

--- a/frontend/src/pages/Mypage/Notification/Notification.styles.ts
+++ b/frontend/src/pages/Mypage/Notification/Notification.styles.ts
@@ -8,7 +8,7 @@ const Root = styled.div<{ isFolded: boolean; notiCount: number }>`
   padding: 1rem 2rem;
   width: 34rem;
   height: ${({ isFolded, notiCount }) =>
-    isFolded ? '11rem' : `calc(11rem + ${notiCount - 3} * 1.75rem)`};
+    isFolded ? '12.5em' : `calc(12.5rem + ${notiCount - 3} * 2.25rem)`};
   border-radius: 0.75rem;
   box-shadow: 4px 4px 8px 4px rgba(85, 85, 85, 0.2);
   display: flex;
@@ -59,8 +59,8 @@ const AllReadButton = styled.button`
 const NotiContainer = styled.ul`
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  margin-top: 0.5rem;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
   padding: 0.25rem;
 `;
 
@@ -90,6 +90,13 @@ const NotiText = styled.div`
 const NotiBold = styled.span`
   display: inline-block;
   font-weight: 700;
+
+  &.user-name {
+    max-width: 3rem;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 
   &.feed-title {
     width: 5.5rem;

--- a/frontend/src/pages/Mypage/Notification/Notification.styles.ts
+++ b/frontend/src/pages/Mypage/Notification/Notification.styles.ts
@@ -6,7 +6,7 @@ import ArrowIcon from 'assets/carouselArrow.svg';
 const Root = styled.div<{ isFolded: boolean; notiCount: number }>`
   position: relative;
   padding: 1rem 2rem;
-  width: 34rem;
+  width: 36rem;
   height: ${({ isFolded, notiCount }) =>
     isFolded ? '12.5em' : `calc(12.5rem + ${notiCount - 3} * 2.25rem)`};
   border-radius: 0.75rem;

--- a/frontend/src/pages/Mypage/Notification/Notification.tsx
+++ b/frontend/src/pages/Mypage/Notification/Notification.tsx
@@ -13,9 +13,9 @@ import { NotiType, NotificationType } from 'types';
 import Styled, { MoreNotiIcon } from './Notification.styles';
 
 const NotiTypeText = {
-  [NotiType.COMMENT_SOS]: '에 도움을 제안했어요! 🙌',
-  [NotiType.COMMENT]: '에 댓글을 남겼습니다. 📮',
-  [NotiType.REPLY]: '의 댓글에 답글을 남겼습니다. 💌',
+  [NotiType.COMMENT_SOS]: '에 도움🙌 을 제안했어요! ',
+  [NotiType.COMMENT]: '에 댓글📮 을 남겼습니다. ',
+  [NotiType.REPLY]: '의 댓글에 답글💌 을 남겼습니다. ',
   [NotiType.LIKE]: '를 좋아합니다. 👍',
 };
 

--- a/frontend/src/pages/Mypage/Notification/Notification.tsx
+++ b/frontend/src/pages/Mypage/Notification/Notification.tsx
@@ -13,10 +13,10 @@ import { NotiType, NotificationType } from 'types';
 import Styled, { MoreNotiIcon } from './Notification.styles';
 
 const NotiTypeText = {
-  [NotiType.COMMENT_SOS]: '에 도움을 제안했어요!',
-  [NotiType.COMMENT]: '에 댓글을 남겼습니다.',
-  [NotiType.REPLY]: '의 댓글에 답글을 남겼습니다.',
-  [NotiType.LIKE]: '를 좋아합니다.',
+  [NotiType.COMMENT_SOS]: '에 도움을 제안했어요! 🙌',
+  [NotiType.COMMENT]: '에 댓글을 남겼습니다. 📮',
+  [NotiType.REPLY]: '의 댓글에 답글을 남겼습니다. 💌',
+  [NotiType.LIKE]: '를 좋아합니다. 👍',
 };
 
 const Notification = () => {
@@ -94,7 +94,9 @@ const Notification = () => {
               <Styled.NotiWrapper key={data.id} onClick={() => handleClickNoti(data)}>
                 <Styled.NotiUserImage src={data.user.imageUrl} />
                 <Styled.NotiText>
-                  <Styled.NotiBold>{data.user.nickname}&nbsp;</Styled.NotiBold>
+                  <Styled.NotiBold className="user-name">
+                    {data.user.nickname}&nbsp;
+                  </Styled.NotiBold>
                   님이&nbsp;
                   <Styled.NotiBold className="feed-title">{data.feed.title}&nbsp;</Styled.NotiBold>
                   프로젝트{NotiTypeText[data.type]}

--- a/frontend/src/pages/Upload/Upload.tsx
+++ b/frontend/src/pages/Upload/Upload.tsx
@@ -29,7 +29,7 @@ const Upload = () => {
       <Header />
       <Styled.Root>
         <Styled.TitleWrapper>
-          <HighLightedText fontSize="1.75rem">🦄 Upload Your Toy</HighLightedText>
+          <HighLightedText fontSize="1.75rem">🦄 Upload Your Toy Project</HighLightedText>
         </Styled.TitleWrapper>
 
         <FeedUploadForm onFeedSubmit={uploadFeed} />

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,9 +30,9 @@ export enum NotiType {
 }
 
 export enum UserHistoryType {
-  MY_LIKED = 'MY_LIKED',
   MY_FEED = 'MY_FEED',
   MY_COMMENT = 'MY_COMMENT',
+  MY_LIKED = 'MY_LIKED',
 }
 
 export interface Author {

--- a/frontend/src/utils/common.ts
+++ b/frontend/src/utils/common.ts
@@ -28,3 +28,7 @@ export const refineDate = (date: string) => {
     .replace(/-/g, '/')
     .replace(/[0-9]+\//, '');
 };
+
+let lastId = 0;
+
+export const genNewId = () => lastId++;

--- a/frontend/src/utils/common.ts
+++ b/frontend/src/utils/common.ts
@@ -29,6 +29,8 @@ export const refineDate = (date: string) => {
     .replace(/[0-9]+\//, '');
 };
 
-let lastId = 0;
+export const genNewId = () => {
+  let lastId = 0;
 
-export const genNewId = () => lastId++;
+  return () => lastId++;
+};


### PR DESCRIPTION
## 작업 내용
2차 UT 이것저것 수정

- [x]  빈값으로 검색을 하면 전체 피드 검색
- [ ]  메인페이지에서 기술스택으로 검색(&트렌드 검색)하고 뒤로가기가 한번에 안 됨 → 왜안돼!!
- [ ]  검색 결과 페이지에 검색 결과가 더 많이 나왔으면 좋겠다 → 수용 🙆‍♀️ → 보류 😬
- [x]  프로필 닉네임 수정 시 2글자까지 입력할 때마다 "이미 사용중인 닉네임입니다"가 보임 → 수용 🙆‍♀️
- [x]  알림 bold 안 된 부분의 내용이 더 중요한 것 같다 → 수용 🙆‍♀️
    - [x]  이모지로 표현하기
- [x]  알림 위아래 간격 너무 좁아서 숨막힘 → 수용 🙆‍♀️
- [x]  마이페이지 좋아요한 '글'보다는 토이프로젝트 느낌이면 좋겠다 → 수용 🙆‍♀️
    - [x]  '토이'로 전체 통일
    - [x]  헤더의 메뉴도
- [x]  글 작성에서 조립중/작성중 아이콘이 recent toy의 조립중/작성중 아이콘과 다르다고함 → 수용 🙆‍♀️
- [x]  Hot Toy Projects
    - [x]  업로드 시에도
    - [x]  헤더에도
- [x]  마이페이지 히스토리 순서 변경 (내작성-내댓글-좋아요)


