### PR TITLE
fix(): 톰캣 문제로 인한 특수 문자 쿼리 허용

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/TomcatWebCustomConfig.java
+++ b/backend/src/main/java/com/wooteco/nolto/TomcatWebCustomConfig.java
@@ -1,0 +1,14 @@
+package com.wooteco.nolto;
+
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TomcatWebCustomConfig implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        factory.addConnectorCustomizers(connector -> connector.setProperty("relaxedQueryChars", "<>[\\]^`{|}"));
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 톰캣 버전으로 인한 특수문자 허용 이슈

Closes #475 



## 주의사항

### 참고자료
- https://dev-jwblog.tistory.com/49