### PR TITLE
feat: 페이지네이션 구현

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/wooteco/nolto/exception/ControllerAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.validation.ConstraintViolationException;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -20,6 +21,14 @@ public class ControllerAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         String defaultMessage = Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage();
+        ExceptionResponse errorResponse = new ExceptionResponse(ErrorType.DATA_BINDING_ERROR.getErrorCode(), defaultMessage);
+        log.info(e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ExceptionResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        String defaultMessage = Objects.requireNonNull(e.getLocalizedMessage());
         ExceptionResponse errorResponse = new ExceptionResponse(ErrorType.DATA_BINDING_ERROR.getErrorCode(), defaultMessage);
         log.info(e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -25,7 +25,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
 
 @Transactional
 @AllArgsConstructor
@@ -121,7 +124,7 @@ public class FeedService {
         return FeedCardResponse.toList(feeds.filter(filterStrategy));
     }
 
-    public FeedCardPaginationResponse findRecentFeeds(String step, Boolean help, Long nextFeedId, Integer countPerPage) {
+    public FeedCardPaginationResponse findRecentFeeds(String step, boolean help, long nextFeedId, int countPerPage) {
         EnumSet<Step> steps = Step.asEnumSet(step);
         Pageable pageable = PageRequest.of(0, countPerPage + NEXT_FEED_COUNT);
         List<Feed> findFeeds = findRecentFeedsWithCondition(help, nextFeedId, steps, pageable);
@@ -134,10 +137,10 @@ public class FeedService {
         return FeedCardPaginationResponse.of(findFeeds, null);
     }
 
-    private List<Feed> findRecentFeedsWithCondition(Boolean help, Long nextFeedId, EnumSet<Step> steps, Pageable pageable) {
-        if (Objects.isNull(help) || !help) {
-            return feedRepository.findWithoutHelp(steps, nextFeedId, pageable);
+    private List<Feed> findRecentFeedsWithCondition(boolean help, long nextFeedId, EnumSet<Step> steps, Pageable pageable) {
+        if (help) {
+            return feedRepository.findWithHelp(steps, help, nextFeedId, pageable);
         }
-        return feedRepository.findWithHelp(steps, help, nextFeedId, pageable);
+        return feedRepository.findWithoutHelp(steps, nextFeedId, pageable);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feeds.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feeds.java
@@ -20,12 +20,4 @@ public class Feeds {
     public List<Feed> filter(FilterStrategy filterStrategy) {
         return filterStrategy.execute(this.feeds);
     }
-
-    public Feed findLastFeed() {
-        return feeds.get(feeds.size() - 1);
-    }
-
-    public List<Feed> getFeeds() {
-        return feeds;
-    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feeds.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feeds.java
@@ -20,4 +20,12 @@ public class Feeds {
     public List<Feed> filter(FilterStrategy filterStrategy) {
         return filterStrategy.execute(this.feeds);
     }
+
+    public Feed findLastFeed() {
+        return feeds.get(feeds.size() - 1);
+    }
+
+    public List<Feed> getFeeds() {
+        return feeds;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Step.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Step.java
@@ -4,6 +4,7 @@ import com.wooteco.nolto.exception.BadRequestException;
 import com.wooteco.nolto.exception.ErrorType;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 
 public enum Step {
     PROGRESS,
@@ -13,5 +14,17 @@ public enum Step {
         return Arrays.stream(values())
                 .filter(step -> step.name().equalsIgnoreCase(value))
                 .findAny().orElseThrow(() -> new BadRequestException(ErrorType.NOT_SUPPORTED_STEP));
+    }
+
+    public static EnumSet<Step> asEnumSet(String value) {
+        final Step findStep = Arrays.stream(values())
+                .filter(step -> step.name().equalsIgnoreCase(value))
+                .findAny()
+                .orElse(null);
+
+        if (findStep == null) {
+            return EnumSet.of(COMPLETE, PROGRESS);
+        }
+        return EnumSet.of(findStep);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/FeedRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/FeedRepository.java
@@ -19,12 +19,14 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     @Query(value = "select feed " +
             "from Feed as feed " +
+            "join fetch feed.author u " +
             "where feed.id <= :feedId and feed.step in :steps " +
             "order by feed.createdDate desc, feed.id desc")
     List<Feed> findWithoutHelp(@Param("steps") EnumSet<Step> steps, @Param("feedId") Long feedId, Pageable pageable);
 
     @Query(value = "select feed " +
             "from Feed as feed " +
+            "join fetch feed.author u " +
             "where feed.id <= :feedId and feed.step in :steps and feed.isSos =:help " +
             "order by feed.createdDate desc, feed.id desc")
     List<Feed> findWithHelp(@Param("steps") EnumSet<Step> steps, @Param("help") Boolean help, @Param("feedId") Long feedId, Pageable pageable);

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/FeedRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/FeedRepository.java
@@ -19,13 +19,13 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     @Query(value = "select feed " +
             "from Feed as feed " +
-            "where feed.id < :feedId and feed.step in :steps " +
+            "where feed.id <= :feedId and feed.step in :steps " +
             "order by feed.createdDate desc, feed.id desc")
     List<Feed> findWithoutHelp(@Param("steps") EnumSet<Step> steps, @Param("feedId") Long feedId, Pageable pageable);
 
     @Query(value = "select feed " +
             "from Feed as feed " +
-            "where feed.id < :feedId and feed.step in :steps and feed.isSos =:help " +
+            "where feed.id <= :feedId and feed.step in :steps and feed.isSos =:help " +
             "order by feed.createdDate desc, feed.id desc")
     List<Feed> findWithHelp(@Param("steps") EnumSet<Step> steps, @Param("help") Boolean help, @Param("feedId") Long feedId, Pageable pageable);
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/FeedRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/FeedRepository.java
@@ -17,14 +17,14 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     Set<Feed> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(String titleText, String contentText);
 
-    @Query(value = "select feed " +
+    @Query(value = "select distinct feed " +
             "from Feed as feed " +
             "join fetch feed.author u " +
             "where feed.id <= :feedId and feed.step in :steps " +
             "order by feed.createdDate desc, feed.id desc")
     List<Feed> findWithoutHelp(@Param("steps") EnumSet<Step> steps, @Param("feedId") Long feedId, Pageable pageable);
 
-    @Query(value = "select feed " +
+    @Query(value = "select distinct feed " +
             "from Feed as feed " +
             "join fetch feed.author u " +
             "where feed.id <= :feedId and feed.step in :steps and feed.isSos =:help " +

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/FeedRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/FeedRepository.java
@@ -1,12 +1,31 @@
 package com.wooteco.nolto.feed.domain.repository;
 
 import com.wooteco.nolto.feed.domain.Feed;
+import com.wooteco.nolto.feed.domain.Step;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
 @Repository
 public interface FeedRepository extends JpaRepository<Feed, Long> {
+
     Set<Feed> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(String titleText, String contentText);
+
+    @Query(value = "select feed " +
+            "from Feed as feed " +
+            "where feed.id < :feedId and feed.step in :steps " +
+            "order by feed.createdDate desc, feed.id desc")
+    List<Feed> findWithoutHelp(@Param("steps") EnumSet<Step> steps, @Param("feedId") Long feedId, Pageable pageable);
+
+    @Query(value = "select feed " +
+            "from Feed as feed " +
+            "where feed.id < :feedId and feed.step in :steps and feed.isSos =:help " +
+            "order by feed.createdDate desc, feed.id desc")
+    List<Feed> findWithHelp(@Param("steps") EnumSet<Step> steps, @Param("help") Boolean help, @Param("feedId") Long feedId, Pageable pageable);
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -13,14 +13,17 @@ import com.wooteco.nolto.user.domain.User;
 import lombok.AllArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
 import java.net.URI;
 import java.util.List;
 
 @AllArgsConstructor
 @RestController
+@Validated
 @RequestMapping("/feeds")
 public class FeedController {
 
@@ -76,12 +79,13 @@ public class FeedController {
 
     @GetMapping("/recent2")
     public ResponseEntity<FeedCardPaginationResponse> recentResponse(@RequestParam(required = false) String step,
-                                                                     @RequestParam(required = false) Boolean help,
-                                                                     @RequestParam(required = false, defaultValue = "10000000") Long nextFeedId,
-                                                                     @RequestParam(required = false, defaultValue = "15") Integer countPerPage) {
-        // TODO : Boolean값에 잘못된 입력값 삽입 시 MethodArgumentTypeMismatchException
-        // TODO : @Pattern(regexp = "\\d*[1-9]\\d*")
-        FeedCardPaginationResponse response = feedService.findRecentFeeds(step, help, nextFeedId, countPerPage);
+                                                                     @RequestParam(required = false, defaultValue = "false") @Valid @Pattern(regexp = "^true$|^false$", message = "Boolean 타입이 아닙니다.") String help,
+                                                                     @RequestParam(required = false, defaultValue = "10000000") @Valid @Pattern(regexp = "^[1-9][0-9]*$", message = "자연수만 가능합니다.") String nextFeedId,
+                                                                     @RequestParam(required = false, defaultValue = "15") @Valid @Pattern(regexp = "^[1-9][0-9]*$", message = "자연수만 가능합니다.") String countPerPage) {
+        FeedCardPaginationResponse response = feedService.findRecentFeeds(step,
+                Boolean.parseBoolean(help),
+                Long.parseLong(nextFeedId),
+                Integer.parseInt(countPerPage));
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -77,11 +77,11 @@ public class FeedController {
     @GetMapping("/recent2")
     public ResponseEntity<FeedCardPaginationResponse> recentResponse(@RequestParam(required = false) String step,
                                                                      @RequestParam(required = false) Boolean help,
-                                                                     @RequestParam(required = false, defaultValue = "10000000") Long lastDrawnFeedId,
+                                                                     @RequestParam(required = false, defaultValue = "10000000") Long nextFeedId,
                                                                      @RequestParam(required = false, defaultValue = "15") Integer countPerPage) {
         // TODO : Boolean값에 잘못된 입력값 삽입 시 MethodArgumentTypeMismatchException
         // TODO : @Pattern(regexp = "\\d*[1-9]\\d*")
-        FeedCardPaginationResponse response = feedService.findRecentFeeds(step, help, lastDrawnFeedId, countPerPage);
+        FeedCardPaginationResponse response = feedService.findRecentFeeds(step, help, nextFeedId, countPerPage);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -5,6 +5,7 @@ import com.wooteco.nolto.auth.UserAuthenticationPrincipal;
 import com.wooteco.nolto.auth.ValidTokenRequired;
 import com.wooteco.nolto.feed.application.FeedService;
 import com.wooteco.nolto.feed.application.LikeService;
+import com.wooteco.nolto.feed.ui.dto.FeedCardPaginationResponse;
 import com.wooteco.nolto.feed.ui.dto.FeedCardResponse;
 import com.wooteco.nolto.feed.ui.dto.FeedRequest;
 import com.wooteco.nolto.feed.ui.dto.FeedResponse;
@@ -71,6 +72,15 @@ public class FeedController {
     public ResponseEntity<List<FeedCardResponse>> recentResponse(@RequestParam(required = false, defaultValue = "all") String filter) {
         List<FeedCardResponse> feeds = feedService.findAll(filter);
         return ResponseEntity.ok(feeds);
+    }
+
+    @GetMapping("/recent2")
+    public ResponseEntity<FeedCardPaginationResponse> recentResponse(@RequestParam(required = false) String step,
+                                                                 @RequestParam(required = false) Boolean help,
+                                                                 @RequestParam(required = false) Long lastDrawnFeedId,
+                                                                 @RequestParam(required = false, defaultValue = "15") Integer countPerPage) {
+        FeedCardPaginationResponse response = feedService.findRecentFeeds(step, help, lastDrawnFeedId, countPerPage);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/hot")

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -76,9 +76,11 @@ public class FeedController {
 
     @GetMapping("/recent2")
     public ResponseEntity<FeedCardPaginationResponse> recentResponse(@RequestParam(required = false) String step,
-                                                                 @RequestParam(required = false) Boolean help,
-                                                                 @RequestParam(required = false) Long lastDrawnFeedId,
-                                                                 @RequestParam(required = false, defaultValue = "15") Integer countPerPage) {
+                                                                     @RequestParam(required = false) Boolean help,
+                                                                     @RequestParam(required = false, defaultValue = "10000000") Long lastDrawnFeedId,
+                                                                     @RequestParam(required = false, defaultValue = "15") Integer countPerPage) {
+        // TODO : Boolean값에 잘못된 입력값 삽입 시 MethodArgumentTypeMismatchException
+        // TODO : @Pattern(regexp = "\\d*[1-9]\\d*")
         FeedCardPaginationResponse response = feedService.findRecentFeeds(step, help, lastDrawnFeedId, countPerPage);
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardPaginationResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardPaginationResponse.java
@@ -1,0 +1,21 @@
+package com.wooteco.nolto.feed.ui.dto;
+
+import com.wooteco.nolto.feed.domain.Feeds;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class FeedCardPaginationResponse {
+
+    private final List<FeedCardResponse> feeds;
+    private final Long lastDrawnFeedId;
+
+    public static FeedCardPaginationResponse of(Feeds feeds) {
+        final List<FeedCardResponse> feedCardResponses = FeedCardResponse.toList(feeds.getFeeds());
+        final Long lastFeedId = feeds.findLastFeed().getId();
+        return new FeedCardPaginationResponse(feedCardResponses, lastFeedId);
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardPaginationResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardPaginationResponse.java
@@ -1,21 +1,24 @@
 package com.wooteco.nolto.feed.ui.dto;
 
-import com.wooteco.nolto.feed.domain.Feeds;
+import com.wooteco.nolto.feed.domain.Feed;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
 public class FeedCardPaginationResponse {
 
     private final List<FeedCardResponse> feeds;
-    private final Long lastDrawnFeedId;
+    private final Long nextFeedId;
 
-    public static FeedCardPaginationResponse of(Feeds feeds) {
-        final List<FeedCardResponse> feedCardResponses = FeedCardResponse.toList(feeds.getFeeds());
-        final Long lastFeedId = feeds.findLastFeed().getId();
-        return new FeedCardPaginationResponse(feedCardResponses, lastFeedId);
+    public static FeedCardPaginationResponse of(List<Feed> findFeeds, Feed nextFeed) {
+        List<FeedCardResponse> feedCardResponses = FeedCardResponse.toList(findFeeds);
+        if (Objects.isNull(nextFeed)) {
+            return new FeedCardPaginationResponse(feedCardResponses, null);
+        }
+        return new FeedCardPaginationResponse(feedCardResponses, nextFeed.getId());
     }
 }

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
@@ -8,6 +8,7 @@ import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.FeedTech;
 import com.wooteco.nolto.feed.domain.Step;
 import com.wooteco.nolto.feed.domain.repository.FeedRepository;
+import com.wooteco.nolto.feed.ui.dto.FeedCardPaginationResponse;
 import com.wooteco.nolto.feed.ui.dto.FeedCardResponse;
 import com.wooteco.nolto.feed.ui.dto.FeedRequest;
 import com.wooteco.nolto.feed.ui.dto.FeedResponse;
@@ -754,6 +755,151 @@ class FeedServiceTest {
         //then
         assertThat(searchFeeds).hasSize(2);
         assertThat(feedIds).contains(firstFeedId, thirdFeedId);
+    }
+
+    @DisplayName("step과 help를 고려한 페이지네이션을 지원한다. (step=all, help=null, lastFeedId=Long.MAX_VALUE countPerPage=2")
+    @Test
+    void stepAllHelpNull() {
+        // given
+        FEED_REQUEST1.setStep("PROGRESS");
+        Long firstFeedId = feedService.create(user1, FEED_REQUEST1);
+        FEED_REQUEST2.setStep("PROGRESS");
+        Long secondFeedId = feedService.create(user1, FEED_REQUEST2);
+        FEED_REQUEST3.setStep("COMPLETE");
+        Long thirdFeedId = feedService.create(user1, FEED_REQUEST3);
+        em.flush();
+        em.clear();
+
+        // when
+        FeedCardPaginationResponse responses = feedService.findRecentFeeds("all", null, Long.MAX_VALUE, 2);
+
+        // then
+        assertThat(responses.getFeeds()).hasSize(2);
+        assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST3.getTitle());
+        assertThat(responses.getFeeds().get(1).getTitle()).isEqualTo(FEED_REQUEST2.getTitle());
+        assertThat(responses.getLastDrawnFeedId()).isEqualTo(secondFeedId);
+    }
+
+    @DisplayName("step과 help를 고려한 페이지네이션을 지원한다. (step=progress, help=null, lastFeedId=Long.MAX_VALUE countPerPage=2")
+    @Test
+    void stepProgressHelpNull() {
+        // given
+        FEED_REQUEST1.setStep("PROGRESS");
+        Long firstFeedId = feedService.create(user1, FEED_REQUEST1);
+        FEED_REQUEST2.setStep("PROGRESS");
+        Long secondFeedId = feedService.create(user1, FEED_REQUEST2);
+        FEED_REQUEST3.setStep("COMPLETE");
+        Long thirdFeedId = feedService.create(user1, FEED_REQUEST3);
+        em.flush();
+        em.clear();
+
+        // when
+        FeedCardPaginationResponse responses = feedService.findRecentFeeds("progress", null, Long.MAX_VALUE, 2);
+
+        // then
+        assertThat(responses.getFeeds()).hasSize(2);
+        assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST2.getTitle());
+        assertThat(responses.getFeeds().get(1).getTitle()).isEqualTo(FEED_REQUEST1.getTitle());
+        assertThat(responses.getLastDrawnFeedId()).isEqualTo(firstFeedId);
+    }
+
+    @DisplayName("step과 help를 고려한 페이지네이션을 지원한다. (step=complete, help=null, lastFeedId=Long.MAX_VALUE countPerPage=2")
+    @Test
+    void stepCompleteHelpNull() {
+        // given
+        FEED_REQUEST1.setStep("PROGRESS");
+        Long firstFeedId = feedService.create(user1, FEED_REQUEST1);
+        FEED_REQUEST2.setStep("PROGRESS");
+        Long secondFeedId = feedService.create(user1, FEED_REQUEST2);
+        FEED_REQUEST3.setStep("COMPLETE");
+        Long thirdFeedId = feedService.create(user1, FEED_REQUEST3);
+        em.flush();
+        em.clear();
+
+        // when
+        FeedCardPaginationResponse responses = feedService.findRecentFeeds("complete", null, Long.MAX_VALUE, 2);
+
+        // then
+        assertThat(responses.getFeeds()).hasSize(1);
+        assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST3.getTitle());
+        assertThat(responses.getLastDrawnFeedId()).isEqualTo(thirdFeedId);
+    }
+
+    @DisplayName("step과 help를 고려한 페이지네이션을 지원한다. (step=all, help=true, lastFeedId=Long.MAX_VALUE countPerPage=3")
+    @Test
+    void stepAllHelpTrue() {
+        // given
+        FEED_REQUEST1.setStep("PROGRESS");
+        FEED_REQUEST1.setSos(true);
+        Long firstFeedId = feedService.create(user1, FEED_REQUEST1);
+        FEED_REQUEST2.setStep("PROGRESS");
+        FEED_REQUEST2.setSos(false);
+        Long secondFeedId = feedService.create(user1, FEED_REQUEST2);
+        FEED_REQUEST3.setStep("COMPLETE");
+        FEED_REQUEST3.setSos(true);
+        Long thirdFeedId = feedService.create(user1, FEED_REQUEST3);
+        em.flush();
+        em.clear();
+
+        // when
+        FeedCardPaginationResponse responses = feedService.findRecentFeeds("all", true, Long.MAX_VALUE, 3);
+
+        // then
+        assertThat(responses.getFeeds()).hasSize(2);
+        assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST3.getTitle());
+        assertThat(responses.getFeeds().get(1).getTitle()).isEqualTo(FEED_REQUEST1.getTitle());
+        assertThat(responses.getLastDrawnFeedId()).isEqualTo(firstFeedId);
+    }
+
+    @DisplayName("step과 help를 고려한 페이지네이션을 지원한다. (step=all, help=true, lastFeedId=thirdFeedId countPerPage=2")
+    @Test
+    void stepAllHelpTrue2() {
+        // given
+        FEED_REQUEST1.setStep("PROGRESS");
+        FEED_REQUEST1.setSos(true);
+        Long firstFeedId = feedService.create(user1, FEED_REQUEST1);
+        FEED_REQUEST2.setStep("PROGRESS");
+        FEED_REQUEST2.setSos(false);
+        Long secondFeedId = feedService.create(user1, FEED_REQUEST2);
+        FEED_REQUEST3.setStep("COMPLETE");
+        FEED_REQUEST3.setSos(true);
+        Long thirdFeedId = feedService.create(user1, FEED_REQUEST3);
+        em.flush();
+        em.clear();
+
+        // when
+        FeedCardPaginationResponse responses = feedService.findRecentFeeds("all", true, thirdFeedId, 3);
+
+        // then
+        assertThat(responses.getFeeds()).hasSize(1);
+        assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST1.getTitle());
+        assertThat(responses.getLastDrawnFeedId()).isEqualTo(firstFeedId);
+    }
+
+    @DisplayName("step과 help를 고려한 페이지네이션을 지원한다. (step=all, help=false, lastFeedId=thirdFeedId countPerPage=2")
+    @Test
+    void stepAllHelpFalse() {
+        // given
+        FEED_REQUEST1.setStep("PROGRESS");
+        FEED_REQUEST1.setSos(true);
+        Long firstFeedId = feedService.create(user1, FEED_REQUEST1);
+        FEED_REQUEST2.setStep("PROGRESS");
+        FEED_REQUEST2.setSos(false);
+        Long secondFeedId = feedService.create(user1, FEED_REQUEST2);
+        FEED_REQUEST3.setStep("COMPLETE");
+        FEED_REQUEST3.setSos(true);
+        Long thirdFeedId = feedService.create(user1, FEED_REQUEST3);
+        em.flush();
+        em.clear();
+
+        // when
+        FeedCardPaginationResponse responses = feedService.findRecentFeeds("all", false, thirdFeedId, 2);
+
+        // then
+        assertThat(responses.getFeeds()).hasSize(2);
+        assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST2.getTitle());
+        assertThat(responses.getFeeds().get(1).getTitle()).isEqualTo(FEED_REQUEST1.getTitle());
+        assertThat(responses.getLastDrawnFeedId()).isEqualTo(firstFeedId);
     }
 
     private void 피드_정보가_같은지_조회(FeedRequest request, Feed feed) {

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
@@ -777,7 +777,7 @@ class FeedServiceTest {
         assertThat(responses.getFeeds()).hasSize(2);
         assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST3.getTitle());
         assertThat(responses.getFeeds().get(1).getTitle()).isEqualTo(FEED_REQUEST2.getTitle());
-        assertThat(responses.getLastDrawnFeedId()).isEqualTo(secondFeedId);
+        assertThat(responses.getNextFeedId()).isEqualTo(firstFeedId);
     }
 
     @DisplayName("step과 help를 고려한 페이지네이션을 지원한다. (step=progress, help=null, lastFeedId=Long.MAX_VALUE countPerPage=2")
@@ -800,7 +800,7 @@ class FeedServiceTest {
         assertThat(responses.getFeeds()).hasSize(2);
         assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST2.getTitle());
         assertThat(responses.getFeeds().get(1).getTitle()).isEqualTo(FEED_REQUEST1.getTitle());
-        assertThat(responses.getLastDrawnFeedId()).isEqualTo(firstFeedId);
+        assertThat(responses.getNextFeedId()).isNull();
     }
 
     @DisplayName("step과 help를 고려한 페이지네이션을 지원한다. (step=complete, help=null, lastFeedId=Long.MAX_VALUE countPerPage=2")
@@ -822,7 +822,7 @@ class FeedServiceTest {
         // then
         assertThat(responses.getFeeds()).hasSize(1);
         assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST3.getTitle());
-        assertThat(responses.getLastDrawnFeedId()).isEqualTo(thirdFeedId);
+        assertThat(responses.getNextFeedId()).isNull();
     }
 
     @DisplayName("step과 help를 고려한 페이지네이션을 지원한다. (step=all, help=true, lastFeedId=Long.MAX_VALUE countPerPage=3")
@@ -848,7 +848,7 @@ class FeedServiceTest {
         assertThat(responses.getFeeds()).hasSize(2);
         assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST3.getTitle());
         assertThat(responses.getFeeds().get(1).getTitle()).isEqualTo(FEED_REQUEST1.getTitle());
-        assertThat(responses.getLastDrawnFeedId()).isEqualTo(firstFeedId);
+        assertThat(responses.getNextFeedId()).isNull();
     }
 
     @DisplayName("step과 help를 고려한 페이지네이션을 지원한다. (step=all, help=true, lastFeedId=thirdFeedId countPerPage=2")
@@ -871,9 +871,10 @@ class FeedServiceTest {
         FeedCardPaginationResponse responses = feedService.findRecentFeeds("all", true, thirdFeedId, 3);
 
         // then
-        assertThat(responses.getFeeds()).hasSize(1);
-        assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST1.getTitle());
-        assertThat(responses.getLastDrawnFeedId()).isEqualTo(firstFeedId);
+        assertThat(responses.getFeeds()).hasSize(2);
+        assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST3.getTitle());
+        assertThat(responses.getFeeds().get(1).getTitle()).isEqualTo(FEED_REQUEST1.getTitle());
+        assertThat(responses.getNextFeedId()).isNull();
     }
 
     @DisplayName("step과 help를 고려한 페이지네이션을 지원한다. (step=all, help=false, lastFeedId=thirdFeedId countPerPage=2")
@@ -897,9 +898,9 @@ class FeedServiceTest {
 
         // then
         assertThat(responses.getFeeds()).hasSize(2);
-        assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST2.getTitle());
-        assertThat(responses.getFeeds().get(1).getTitle()).isEqualTo(FEED_REQUEST1.getTitle());
-        assertThat(responses.getLastDrawnFeedId()).isEqualTo(firstFeedId);
+        assertThat(responses.getFeeds().get(0).getTitle()).isEqualTo(FEED_REQUEST3.getTitle());
+        assertThat(responses.getFeeds().get(1).getTitle()).isEqualTo(FEED_REQUEST2.getTitle());
+        assertThat(responses.getNextFeedId()).isEqualTo(firstFeedId);
     }
 
     private void 피드_정보가_같은지_조회(FeedRequest request, Feed feed) {

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
@@ -771,7 +771,7 @@ class FeedServiceTest {
         em.clear();
 
         // when
-        FeedCardPaginationResponse responses = feedService.findRecentFeeds("all", null, Long.MAX_VALUE, 2);
+        FeedCardPaginationResponse responses = feedService.findRecentFeeds("all", false, Long.MAX_VALUE, 2);
 
         // then
         assertThat(responses.getFeeds()).hasSize(2);
@@ -794,7 +794,7 @@ class FeedServiceTest {
         em.clear();
 
         // when
-        FeedCardPaginationResponse responses = feedService.findRecentFeeds("progress", null, Long.MAX_VALUE, 2);
+        FeedCardPaginationResponse responses = feedService.findRecentFeeds("progress", false, Long.MAX_VALUE, 2);
 
         // then
         assertThat(responses.getFeeds()).hasSize(2);
@@ -817,7 +817,7 @@ class FeedServiceTest {
         em.clear();
 
         // when
-        FeedCardPaginationResponse responses = feedService.findRecentFeeds("complete", null, Long.MAX_VALUE, 2);
+        FeedCardPaginationResponse responses = feedService.findRecentFeeds("complete", false, Long.MAX_VALUE, 2);
 
         // then
         assertThat(responses.getFeeds()).hasSize(1);


### PR DESCRIPTION
## 작업 내용
- 요청 양식
`GET: /feeds/recent2?step=progress&help=true&nextFeedId=2&countPerPage=5`
    - 모든 파라미터는 생략 가능
        - countPerPage 생략 시 기본으로 15개로 지정

- 응답 양식
```
{
    "feeds": [
        {
            "author": {
                "id": 1,
                "nickname": "미키",
                "imageUrl": "https://dksykemwl00pf.cloudfront.net/amazzi.jpeg"
            },
            "id": 2,
            "title": "title2",
            "content": "content2",
            "step": "COMPLETE",
            "sos": false,
            "thumbnailUrl": "https://dksykemwl00pf.cloudfront.net/KakaoTalk_Photo_2021-07-19-14-25-01.png"
        },
        {
            "author": {
                "id": 1,
                "nickname": "미키",
                "imageUrl": "https://dksykemwl00pf.cloudfront.net/amazzi.jpeg"
            },
            "id": 1,
            "title": "title1",
            "content": "content1",
            "step": "PROGRESS",
            "sos": true,
            "thumbnailUrl": "https://dksykemwl00pf.cloudfront.net/KakaoTalk_Photo_2021-07-19-14-25-01.png"
        }
    ],
    "nextFeedId": null
}
```
- RequestParam의 유효성을 검증하기 위해서 FeedController에 `@Validated` 추가
    - 해당 제약 조건을 만족하지 않는다면, ConstraintViolationException 예외 발생
    - 해당 ControllerAdvice에 해당 예외 잡아둠
    - 예외 메시지에 "FeedController.검사한 메서드"까지 포함되어 나옴

Closes #34

## 주의사항
- 현재 API 명명이 `/recent2`로 되어있음. 나중에 수정 요망
- `/recent2` 에서만 step과 help를 분리함 
    - `/search`에서는 filter로 여전히 SOS, PROGRESS, COMPLETE 구분 중
- 문서화 및 `/recent`로의 api 변경은 dev 서버에서 검증 이후에 진행 예정
