### PR TITLE
[FE] 스타일링 세세한 부분 수정

### DIFF
--- a/frontend/src/components/@common/ToggleList/ToggleList.styles.ts
+++ b/frontend/src/components/@common/ToggleList/ToggleList.styles.ts
@@ -4,7 +4,8 @@ import StacksMoreSvg from 'assets/stacksMore.svg';
 
 const Root = styled.div<{ width: string; height: string; $isToggled: boolean }>`
   display: flex;
-  gap: 1rem;
+  align-items: center;
+  gap: 0.5rem;
   overflow: hidden;
   transition: all 0.3s ease-in;
 

--- a/frontend/src/components/CommentModule/@common/CommentForm/CommentForm.tsx
+++ b/frontend/src/components/CommentModule/@common/CommentForm/CommentForm.tsx
@@ -57,7 +57,7 @@ const CommentForm = ({ onSubmit, isRootComment = false }: Props) => {
           ) : (
             <CommentFormInput value={MESSAGES.NEED_LOGIN} disabled={true} />
           )}
-          <SendButton hasShadow={false} disabled={!isLogin}>
+          <SendButton size="1.5rem" hasShadow={false} disabled={!isLogin}>
             <SendIcon width="21px" height="21px" />
           </SendButton>
         </Styled.FormInputWrapper>

--- a/frontend/src/components/CroppedEllipse/CroppedEllipse.styles.ts
+++ b/frontend/src/components/CroppedEllipse/CroppedEllipse.styles.ts
@@ -58,7 +58,7 @@ const Horse = styled(HorseIcon)`
   height: auto;
   position: absolute;
   right: 10%;
-  bottom: 15%;
+  bottom: 13%;
   transform: rotate(-12deg);
 
   &:hover {

--- a/frontend/src/components/Header/Header.styles.ts
+++ b/frontend/src/components/Header/Header.styles.ts
@@ -4,9 +4,7 @@ import LogoIcon from 'assets/logo.svg';
 import LogoSimpleIcon from 'assets/logoSimple.svg';
 import { hoverUnderline } from 'commonStyles';
 import TextButton from 'components/@common/TextButton/TextButton';
-import IconButtonComponent from 'components/@common/IconButton/IconButton';
 import SearchBarComponent from 'components/SearchBar/SearchBar';
-import UserProfileComponent from 'components/UserProfile/UserProfile';
 import { FONT_SIZE, Z_INDEX } from 'constants/styles';
 import { BREAK_POINTS, MEDIA_QUERY } from 'constants/mediaQuery';
 import { PALETTE } from 'constants/palette';
@@ -19,6 +17,7 @@ const Root = styled.header<{ isFolded: boolean }>`
   top: 0;
   height: ${HEIGHT.HEADER};
   width: 100%;
+  padding: 0 1rem;
   z-index: ${Z_INDEX.HEADER};
   box-shadow: ${({ isFolded }) => !isFolded && 'rgb(0 0 0 / 25%) 0px 4px 4px'};
 
@@ -79,13 +78,16 @@ const NavContainer = styled.nav`
 
   & li {
     text-align: center;
+
+    &.buttons-container {
+      margin-left: 0.5rem;
+    }
   }
 
   & .nav-link {
     font-size: ${FONT_SIZE.MEDIUM};
     color: ${PALETTE.WHITE_400};
     display: block;
-    padding-bottom: 4px;
     ${hoverUnderline};
 
     &.selected::after {
@@ -156,7 +158,7 @@ const UserContainer = styled.div`
   justify-content: center;
   align-items: center;
   flex-shrink: 0;
-  padding: 0 0.5rem;
+  margin-left: 1rem;
 `;
 
 export default {

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -70,7 +70,7 @@ const Header = ({ isFolded = false }: Props) => {
             Nolto Team
           </NavLink>
         </li>
-        <li>
+        <li className="buttons-container">
           <Styled.ButtonsContainer>
             <Link to={ROUTE.UPLOAD} className="upload-link">
               <IconButton size="2rem">

--- a/frontend/src/components/RecentFeedsContent/RecentFeedsContent.styles.ts
+++ b/frontend/src/components/RecentFeedsContent/RecentFeedsContent.styles.ts
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 const Root = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 3rem;
 `;
 
 const StepChipsContainer = styled.div`

--- a/frontend/src/components/RecentFeedsContent/RecentFeedsContent.tsx
+++ b/frontend/src/components/RecentFeedsContent/RecentFeedsContent.tsx
@@ -26,7 +26,7 @@ const RecentFeedsContent = () => {
 
   return (
     <Styled.Root>
-      <FlexContainer flexDirection="column" gap="1rem">
+      <FlexContainer flexDirection="column" alignItems="center" gap="1.5rem">
         <HighLightedText fontSize={FONT_SIZE.X_LARGE}>Recent Toys</HighLightedText>
         <Styled.StepChipsContainer>
           <Styled.Button type="button" onClick={() => toggleLevel(FilterType.PROGRESS)}>

--- a/frontend/src/components/RegularFeedCard/RegularFeedCard.styles.ts
+++ b/frontend/src/components/RegularFeedCard/RegularFeedCard.styles.ts
@@ -55,6 +55,7 @@ const Content = styled.div`
   display: flex;
   flex-direction: column;
   height: 6rem;
+  margin-top: 0.5rem;
   padding: 0.25rem;
   gap: 0.25rem;
 

--- a/frontend/src/components/TrendTechs/TrendTechs.styles.ts
+++ b/frontend/src/components/TrendTechs/TrendTechs.styles.ts
@@ -6,11 +6,8 @@ import { BREAK_POINTS } from 'constants/mediaQuery';
 
 const Root = styled.div`
   display: flex;
-  gap: 0.75rem;
   align-items: center;
   width: 100%;
-  overflow-y: hidden;
-  overflow-x: auto;
 
   & span {
     color: ${PALETTE.WHITE_400};

--- a/frontend/src/pages/FeedDetail/FeedDetailContent/FeedDetailContent.styles.ts
+++ b/frontend/src/pages/FeedDetail/FeedDetailContent/FeedDetailContent.styles.ts
@@ -143,6 +143,7 @@ const DetailsContent = styled.div`
 
 const DetailsPair = styled.div`
   display: flex;
+  align-items: center;
   gap: 1.75rem;
 
   @media ${MEDIA_QUERY.TABLET_SMALL} {

--- a/frontend/src/pages/Home/Home.styles.ts
+++ b/frontend/src/pages/Home/Home.styles.ts
@@ -7,6 +7,7 @@ import Avatar from 'components/@common/Avatar/Avatar';
 import IconButtonComponent from 'components/@common/IconButton/IconButton';
 import { PALETTE } from 'constants/palette';
 import { FONT_SIZE, Z_INDEX } from 'constants/styles';
+import { MEDIA_QUERY } from 'constants/mediaQuery';
 import { hoverUnderline } from 'commonStyles';
 import ArrowIcon from 'assets/carouselArrow.svg';
 
@@ -21,8 +22,9 @@ const SearchContainer = styled.div`
   align-items: center;
   justify-content: center;
   z-index: ${Z_INDEX.HOME_SEARCHBAR};
-  width: 100%;
-  padding-bottom: 3.5rem;
+  max-width: 736px;
+  margin: 0 auto;
+  padding: 0 1rem;
 
   & > .search-bar {
     z-index: ${Z_INDEX.HOME_SEARCHBAR};
@@ -83,8 +85,7 @@ const ContentArea = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 2rem;
-  top: -1.5rem;
-  padding: 3rem 0;
+  margin-top: 8rem;
 `;
 
 const TitleWrapper = styled.div`
@@ -92,6 +93,7 @@ const TitleWrapper = styled.div`
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  padding: 0 1rem;
 `;
 
 const SectionTitle = styled(HighLightedText)`

--- a/frontend/src/pages/Home/HomeFeedsContent/HomeFeedsContent.styles.ts
+++ b/frontend/src/pages/Home/HomeFeedsContent/HomeFeedsContent.styles.ts
@@ -5,7 +5,7 @@ const Root = styled.div`
   gap: 1rem;
   width: 100%;
   overflow: auto;
-  padding-left: 1rem;
+  padding: 0 1rem;
 `;
 
 export default { Root };

--- a/frontend/src/pages/Mypage/Notification/Notification.styles.ts
+++ b/frontend/src/pages/Mypage/Notification/Notification.styles.ts
@@ -138,7 +138,7 @@ const MoreNotiButton = styled.button`
   color: ${PALETTE.ORANGE_400};
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
 
   span {
     color: inherit;

--- a/frontend/src/pages/Mypage/Notification/Notification.tsx
+++ b/frontend/src/pages/Mypage/Notification/Notification.tsx
@@ -111,7 +111,7 @@ const Notification = () => {
 
       {notiData.length > defaultNotiCountToShow && (
         <Styled.MoreNotiButton onClick={() => setMoreNotiFolded(!moreNotiFolded)}>
-          <MoreNotiIcon width="8px" fill={PALETTE.ORANGE_400} isFolded={moreNotiFolded} />
+          <MoreNotiIcon width="16px" fill={PALETTE.ORANGE_400} isFolded={moreNotiFolded} />
           <span>알림 더보기</span>
         </Styled.MoreNotiButton>
       )}


### PR DESCRIPTION
## 작업 내용
- Searchbar 크기 줄임
- 댓글 전송 아이콘, 알림 더보기 아이콘 크기 설정
- Hot Toys와 헤더 사이 간격 넓히기
- Home의 '완성된 프로젝트' 소제목과 피드들 왼쪽 정렬 다름
- 피드 상세 페이지의 기술 스택 정렬 수정
- RegularFeedCard 사진과 글자 간격 조정
- 헤더 넘 쫍은거 간격들 넓힙
- 최신 피드 목록 중앙정렬 (이게 더 나아 보여서...)

## 스크린샷
![image](https://user-images.githubusercontent.com/44080404/132513494-87a1cb1c-3671-4ec6-a14e-a087e13832ae.png)

---

![image](https://user-images.githubusercontent.com/44080404/132513719-28bd7902-2c1d-4cfe-847c-a7e57b25a9f2.png)

---

![image](https://user-images.githubusercontent.com/44080404/132513799-a72a33f5-53b4-41f2-ac01-d90b34ceb8dd.png)

---

![image](https://user-images.githubusercontent.com/44080404/132513827-b127c95e-9529-4097-a50a-d7b49b674113.png)


## 주의사항
- TrendTech overflow 어떻게 하지요?
