### PR TITLE
feat(application.yml): gzip을 위한 설정 추가

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,7 +25,12 @@ spring:
       enabled: always
   main:
     allow-bean-definition-overriding: true
-
+server:
+  compression:
+    enabled: true
+    mime-types: text/html,text/plain,text/css,application/javascript,application/json
+# TODO Transfer-Encoding : chunked 일시 min-response-size설정은 무시된다 (Content-Length가 -1임) 방법을 찾자
+#    min-response-size: 500
 application:
   cors:
     allow-origin: "*"

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -29,8 +29,6 @@ server:
   compression:
     enabled: true
     mime-types: text/html,text/plain,text/css,application/javascript,application/json
-# TODO Transfer-Encoding : chunked 일시 min-response-size설정은 무시된다 (Content-Length가 -1임) 방법을 찾자
-#    min-response-size: 500
 application:
   cors:
     allow-origin: "*"


### PR DESCRIPTION
## 작업 내용
``` yaml
server:
  compression:
    enabled: true
    mime-types: text/html,text/plain,text/css,application/javascript,application/json
# TODO Transfer-Encoding : chunked 일시 min-response-size설정은 무시된다 (Content-Length가 -1임) 방법을 찾자
#    min-response-size: 500
```

Closes #519

## 주의사항
- 응답 Content의 용량이 320byte 일때 압축시 370byte로 늘어남 압축 최소 용량 조건을 500으로 할 수 있는 방법을 찾자