### PR TITLE
refactor(): 롬복 정책에 따른 롬복 어노테이션 정리 및 테스트 코드 정리

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/BaseEntity.java
+++ b/backend/src/main/java/com/wooteco/nolto/BaseEntity.java
@@ -11,8 +11,8 @@ import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
 @MappedSuperclass
-@Getter
 @EntityListeners(AuditingEntityListener.class)
+@Getter
 public abstract class BaseEntity {
 
     @CreatedDate

--- a/backend/src/main/java/com/wooteco/nolto/DataLoader.java
+++ b/backend/src/main/java/com/wooteco/nolto/DataLoader.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @Profile("local")
@@ -34,6 +35,7 @@ public class DataLoader implements ApplicationRunner {
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
 
+    private static final String URL = "https://github.com/woowacourse-teams/2021-nolto";
     private static final String DEFAULT_IMAGE = "https://dksykemwl00pf.cloudfront.net/amazzi.jpeg";
 
     @Override
@@ -54,11 +56,28 @@ public class DataLoader implements ApplicationRunner {
         Tech saveTech1 = techRepository.save(tech1);
         Tech saveTech2 = techRepository.save(tech2);
 
-        Feed feed1 = new Feed("title1", "content1", Step.PROGRESS, true, "https://github.com/woowacourse-teams/2021-nolto", "", "https://dksykemwl00pf.cloudfront.net/KakaoTalk_Photo_2021-07-19-14-25-01.png").writtenBy(mickey);
-        Feed feed2 = new Feed("title2", "content2", Step.COMPLETE, false, "https://github.com/woowacourse-teams/2021-nolto", "http://woowa.jofilm.com", "https://dksykemwl00pf.cloudfront.net/KakaoTalk_Photo_2021-07-19-14-25-01.png").writtenBy(mickey);
-        feed1.changeTechs(Arrays.asList(saveTech1));
-        feed2.changeTechs(Arrays.asList(saveTech1));
-        feed2.changeTechs(Arrays.asList(saveTech2));
+        Feed feed1 = Feed.builder()
+                .title("title1")
+                .content("content1")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl(URL)
+                .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/KakaoTalk_Photo_2021-07-19-14-25-01.png")
+                .build().writtenBy(mickey);
+
+        Feed feed2 = Feed.builder()
+                .title("title2")
+                .content("content2")
+                .step(Step.COMPLETE)
+                .isSos(false)
+                .storageUrl(URL)
+                .deployedUrl(URL)
+                .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/KakaoTalk_Photo_2021-07-19-14-25-01.png")
+                .build().writtenBy(mickey);
+
+        feed1.changeTechs(Collections.singletonList(saveTech1));
+        feed2.changeTechs(Collections.singletonList(saveTech1));
+        feed2.changeTechs(Collections.singletonList(saveTech2));
 
         Feed saveFeed1 = feedRepository.save(feed1);
         feedRepository.save(feed2);

--- a/backend/src/main/java/com/wooteco/nolto/DataLoader.java
+++ b/backend/src/main/java/com/wooteco/nolto/DataLoader.java
@@ -12,7 +12,7 @@ import com.wooteco.nolto.tech.domain.Tech;
 import com.wooteco.nolto.tech.domain.TechRepository;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
@@ -23,9 +23,9 @@ import java.util.Arrays;
 import java.util.List;
 
 @Profile("local")
-@Component
-@AllArgsConstructor
 @Transactional
+@Component
+@RequiredArgsConstructor
 public class DataLoader implements ApplicationRunner {
 
     private final FeedRepository feedRepository;

--- a/backend/src/main/java/com/wooteco/nolto/auth/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/AuthenticationPrincipalConfig.java
@@ -4,7 +4,7 @@ import com.wooteco.nolto.auth.application.AuthService;
 import com.wooteco.nolto.auth.ui.AuthInterceptor;
 import com.wooteco.nolto.auth.ui.MemberArgumentResolver;
 import com.wooteco.nolto.auth.ui.UserArgumentResolver;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -14,7 +14,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import java.util.List;
 
 @Configuration
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
     private final AuthService authService;
 

--- a/backend/src/main/java/com/wooteco/nolto/auth/application/AuthService.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/application/AuthService.java
@@ -11,7 +11,7 @@ import com.wooteco.nolto.exception.NotFoundException;
 import com.wooteco.nolto.exception.UnauthorizedException;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 @Transactional
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class AuthService {
 
     public static final String IDENTIFIER = "(%d)";

--- a/backend/src/main/java/com/wooteco/nolto/auth/domain/OAuthClientProvider.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/domain/OAuthClientProvider.java
@@ -10,8 +10,8 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
-@RequiredArgsConstructor
 @Component
+@RequiredArgsConstructor
 public class OAuthClientProvider {
 
     private final List<OAuthClient> oAuthClients;

--- a/backend/src/main/java/com/wooteco/nolto/auth/domain/SocialOAuthInfoProvider.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/domain/SocialOAuthInfoProvider.java
@@ -10,8 +10,8 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
-@RequiredArgsConstructor
 @Component
+@RequiredArgsConstructor
 public class SocialOAuthInfoProvider {
 
     private final List<SocialOAuthInfo> socialOAuthInfos;

--- a/backend/src/main/java/com/wooteco/nolto/auth/infrastructure/JwtTokenProvider.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/infrastructure/JwtTokenProvider.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 
-
 @Component
 public class JwtTokenProvider {
     @Value("${security.jwt.token.secret-key}")

--- a/backend/src/main/java/com/wooteco/nolto/auth/infrastructure/oauth/dto/GithubUserResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/infrastructure/oauth/dto/GithubUserResponse.java
@@ -2,7 +2,6 @@ package com.wooteco.nolto.auth.infrastructure.oauth.dto;
 
 import com.wooteco.nolto.auth.domain.SocialType;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,7 +9,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class GithubUserResponse implements OAuthUserResponse {
     private Long id;
     private String login;

--- a/backend/src/main/java/com/wooteco/nolto/auth/infrastructure/oauth/dto/GoogleUserResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/infrastructure/oauth/dto/GoogleUserResponse.java
@@ -2,15 +2,13 @@ package com.wooteco.nolto.auth.infrastructure.oauth.dto;
 
 import com.wooteco.nolto.auth.domain.SocialType;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Getter
 @Setter
+@NoArgsConstructor
 public class GoogleUserResponse implements OAuthUserResponse {
     private String sub;
     private String name;

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/AuthInterceptor.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/AuthInterceptor.java
@@ -5,7 +5,7 @@ import com.wooteco.nolto.auth.application.AuthService;
 import com.wooteco.nolto.auth.infrastructure.AuthorizationExtractor;
 import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.exception.UnauthorizedException;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Objects;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class AuthInterceptor implements HandlerInterceptor {
     private final AuthService authService;
 

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/MemberArgumentResolver.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/MemberArgumentResolver.java
@@ -4,7 +4,7 @@ import com.wooteco.nolto.auth.MemberAuthenticationPrincipal;
 import com.wooteco.nolto.auth.application.AuthService;
 import com.wooteco.nolto.auth.infrastructure.AuthorizationExtractor;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -14,7 +14,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Objects;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final AuthService authService;

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/OAuthController.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/OAuthController.java
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequiredArgsConstructor
 @RestController
+@RequiredArgsConstructor
 public class OAuthController {
     private final AuthService authService;
 

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/UserArgumentResolver.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/UserArgumentResolver.java
@@ -6,7 +6,7 @@ import com.wooteco.nolto.auth.infrastructure.AuthorizationExtractor;
 import com.wooteco.nolto.exception.NotFoundException;
 import com.wooteco.nolto.user.domain.User;
 import io.jsonwebtoken.JwtException;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -16,7 +16,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Objects;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class UserArgumentResolver implements HandlerMethodArgumentResolver {
     private final AuthService authService;
 

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/OAuthRedirectResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/OAuthRedirectResponse.java
@@ -1,16 +1,21 @@
 package com.wooteco.nolto.auth.ui.dto;
 
 import com.wooteco.nolto.auth.domain.SocialOAuthInfo;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class OAuthRedirectResponse {
     private final String client_id;
     private final String redirect_uri;
     private final String scope;
     private final String response_type;
+
+    public OAuthRedirectResponse(String client_id, String redirect_uri, String scope, String response_type) {
+        this.client_id = client_id;
+        this.redirect_uri = redirect_uri;
+        this.scope = scope;
+        this.response_type = response_type;
+    }
 
     public static OAuthRedirectResponse of(SocialOAuthInfo socialOAuthInfo) {
         return new OAuthRedirectResponse(

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/OAuthTokenResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/OAuthTokenResponse.java
@@ -1,14 +1,18 @@
 package com.wooteco.nolto.auth.ui.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class OAuthTokenResponse {
     private String token_type;
     private String scope;
     private String access_token;
+
+    public OAuthTokenResponse(String token_type, String scope, String access_token) {
+        this.token_type = token_type;
+        this.scope = scope;
+        this.access_token = access_token;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/TokenRequest.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/TokenRequest.java
@@ -1,6 +1,5 @@
 package com.wooteco.nolto.auth.ui.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,7 +10,6 @@ import javax.validation.constraints.NotBlank;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class TokenRequest {
 
     @Email(message = "올바른 Email 양식이 아닙니다.")
@@ -20,5 +18,4 @@ public class TokenRequest {
 
     @NotBlank(message = "password는 빈 값일 수 없습니다.")
     private String password;
-
 }

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/TokenResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/TokenResponse.java
@@ -1,12 +1,14 @@
 package com.wooteco.nolto.auth.ui.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
-@AllArgsConstructor
+@Setter
 public class TokenResponse {
+    private String accessToken;
 
-    private final String accessToken;
-
+    public TokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/exception/ErrorType.java
+++ b/backend/src/main/java/com/wooteco/nolto/exception/ErrorType.java
@@ -1,10 +1,10 @@
 package com.wooteco.nolto.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public enum ErrorType {
     DATA_BINDING_ERROR("common-001", "필수 요청값이 비었습니다"),
     LOGIC_ERROR("common-002", "서버 내부의 에러입니다."),
@@ -39,6 +39,6 @@ public enum ErrorType {
     NOTIFICATION_NOT_FOUND("member-002", "존재하지 않는 알림입니다."),
     UNAUTHORIZED_DELETE_NOTIFICATION("member-003", "알림은 본인만 삭제할 수 있습니다.");
 
-    private String errorCode;
-    private String message;
+    private final String errorCode;
+    private final String message;
 }

--- a/backend/src/main/java/com/wooteco/nolto/exception/dto/ExceptionResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/exception/dto/ExceptionResponse.java
@@ -1,12 +1,15 @@
 package com.wooteco.nolto.exception.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
 @Getter
 public class ExceptionResponse {
 
-    private final String errorCode;
-    private final String message;
+    private String errorCode;
+    private String message;
+
+    public ExceptionResponse(String errorCode, String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/CommentLikeService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/CommentLikeService.java
@@ -6,13 +6,13 @@ import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.feed.domain.CommentLike;
 import com.wooteco.nolto.feed.domain.repository.CommentLikeRepository;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@AllArgsConstructor
 @Transactional
 @Service
+@RequiredArgsConstructor
 public class CommentLikeService {
 
     private final CommentService commentService;

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
@@ -11,7 +11,7 @@ import com.wooteco.nolto.feed.ui.dto.ReplyResponse;
 import com.wooteco.nolto.notification.application.NotificationCommentDeleteEvent;
 import com.wooteco.nolto.notification.application.NotificationEvent;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +20,7 @@ import java.util.List;
 
 @Transactional
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class CommentService {
 
     private final CommentRepository commentRepository;

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedService.java
@@ -17,7 +17,7 @@ import com.wooteco.nolto.image.application.ImageService;
 import com.wooteco.nolto.notification.application.NotificationFeedDeleteEvent;
 import com.wooteco.nolto.tech.domain.TechRepository;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,8 +31,8 @@ import java.util.List;
 import java.util.Set;
 
 @Transactional
-@AllArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class FeedService {
 
     private static final int NEXT_FEED_COUNT = 1;

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/FeedTechService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/FeedTechService.java
@@ -5,7 +5,7 @@ import com.wooteco.nolto.feed.domain.FeedTech;
 import com.wooteco.nolto.feed.domain.repository.FeedTechRepository;
 import com.wooteco.nolto.tech.domain.Tech;
 import com.wooteco.nolto.tech.domain.TechRepository;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,9 +14,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@AllArgsConstructor
-@Service
 @Transactional
+@Service
+@RequiredArgsConstructor
 public class FeedTechService {
 
     private final TechRepository techRepository;

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/LikeService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/LikeService.java
@@ -6,17 +6,16 @@ import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.Like;
 import com.wooteco.nolto.feed.domain.repository.LikeRepository;
 import com.wooteco.nolto.notification.application.NotificationEvent;
-import com.wooteco.nolto.notification.domain.NotificationType;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 
 @Transactional
-@AllArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class LikeService {
 
     private final LikeRepository likeRepository;

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/searchstrategy/SearchStrategyConfig.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/searchstrategy/SearchStrategyConfig.java
@@ -2,12 +2,12 @@ package com.wooteco.nolto.feed.application.searchstrategy;
 
 import com.wooteco.nolto.feed.application.FeedTechService;
 import com.wooteco.nolto.feed.domain.repository.FeedRepository;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class SearchStrategyConfig {
 
     private final FeedRepository feedRepository;

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
@@ -48,26 +48,14 @@ public class Comment extends BaseEntity {
     @OneToMany(mappedBy = "parentComment", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> replies = new ArrayList<>();
 
+    public Comment(String content, boolean helper) {
+        this(null, content, helper);
+    }
+
     public Comment(Long id, String content, boolean helper) {
         this.id = id;
         this.content = content;
         this.helper = helper;
-    }
-
-    public Comment(String content, boolean helper) {
-        this.content = content;
-        this.helper = helper;
-    }
-
-    public Comment(Long id, String content, boolean helper, Feed feed, User author, Comment parentComment, List<CommentLike> likes, List<Comment> replies) {
-        this.id = id;
-        this.content = content;
-        this.helper = helper;
-        this.feed = feed;
-        this.author = author;
-        this.parentComment = parentComment;
-        this.likes = likes;
-        this.replies = replies;
     }
 
     public static Comment createReply(String content, boolean helper) {

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
@@ -5,6 +5,7 @@ import com.wooteco.nolto.exception.BadRequestException;
 import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.exception.UnauthorizedException;
 import com.wooteco.nolto.user.domain.User;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,7 +17,7 @@ import java.util.Optional;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
@@ -5,8 +5,8 @@ import com.wooteco.nolto.exception.BadRequestException;
 import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.exception.UnauthorizedException;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -14,9 +14,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-@Getter
 @Entity
-@AllArgsConstructor
+@Getter
+@NoArgsConstructor
 public class Comment extends BaseEntity {
 
     @Id
@@ -47,9 +47,6 @@ public class Comment extends BaseEntity {
     @OneToMany(mappedBy = "parentComment", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> replies = new ArrayList<>();
 
-    public Comment() {
-    }
-
     public Comment(Long id, String content, boolean helper) {
         this.id = id;
         this.content = content;
@@ -59,6 +56,17 @@ public class Comment extends BaseEntity {
     public Comment(String content, boolean helper) {
         this.content = content;
         this.helper = helper;
+    }
+
+    public Comment(Long id, String content, boolean helper, Feed feed, User author, Comment parentComment, List<CommentLike> likes, List<Comment> replies) {
+        this.id = id;
+        this.content = content;
+        this.helper = helper;
+        this.feed = feed;
+        this.author = author;
+        this.parentComment = parentComment;
+        this.likes = likes;
+        this.replies = replies;
     }
 
     public static Comment createReply(String content, boolean helper) {

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/CommentLike.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/CommentLike.java
@@ -1,6 +1,7 @@
 package com.wooteco.nolto.feed.domain;
 
 import com.wooteco.nolto.user.domain.User;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,7 +10,7 @@ import java.util.Objects;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentLike {
 
     @Id

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/CommentLike.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/CommentLike.java
@@ -2,12 +2,14 @@ package com.wooteco.nolto.feed.domain;
 
 import com.wooteco.nolto.user.domain.User;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.Objects;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class CommentLike {
 
     @Id
@@ -21,9 +23,6 @@ public class CommentLike {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_comment_likes_to_comment"), nullable = false)
     private Comment comment;
-
-    public CommentLike() {
-    }
 
     public CommentLike(User user, Comment comment) {
         this.user = user;

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
@@ -6,6 +6,7 @@ import com.wooteco.nolto.exception.BadRequestException;
 import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.tech.domain.Tech;
 import com.wooteco.nolto.user.domain.User;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,7 +21,7 @@ import java.util.stream.Collectors;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Feed extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
@@ -7,6 +7,7 @@ import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.tech.domain.Tech;
 import com.wooteco.nolto.user.domain.User;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -63,18 +64,9 @@ public class Feed extends BaseEntity {
     @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
-    public Feed(String title, String content, Step step, boolean isSos, String storageUrl, String deployedUrl, String thumbnailUrl) {
-        this(null, title, content, step, isSos, storageUrl, deployedUrl, thumbnailUrl, 0, null, new ArrayList<>());
-    }
-
+    @Builder
     public Feed(Long id, String title, String content, Step step, boolean isSos, String storageUrl,
-                String deployedUrl, String thumbnailUrl) {
-        this(id, title, content, step, isSos, storageUrl, deployedUrl, thumbnailUrl, 0, null,
-                new ArrayList<>());
-    }
-
-    public Feed(Long id, String title, String content, Step step, boolean isSos, String storageUrl,
-                String deployedUrl, String thumbnailUrl, int views, User author, List<Like> likes) {
+                String deployedUrl, String thumbnailUrl, int views, User author) {
         validateStep(step, deployedUrl);
         this.id = id;
         this.title = title;
@@ -86,7 +78,9 @@ public class Feed extends BaseEntity {
         this.thumbnailUrl = thumbnailUrl;
         this.views = views;
         this.author = author;
-        this.likes = likes;
+        this.likes = new ArrayList<>();
+        this.feedTechs = new ArrayList<>();
+        this.comments = new ArrayList<>();
     }
 
     public Feed writtenBy(User author) {

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feed.java
@@ -18,10 +18,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-
+@Entity
 @Getter
 @NoArgsConstructor
-@Entity
 public class Feed extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/FeedTech.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/FeedTech.java
@@ -1,15 +1,16 @@
 package com.wooteco.nolto.feed.domain;
 
 import com.wooteco.nolto.tech.domain.Tech;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.Objects;
 
-@Getter
-@NoArgsConstructor
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FeedTech {
 
     @Id

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Feeds.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Feeds.java
@@ -1,14 +1,15 @@
 package com.wooteco.nolto.feed.domain;
 
-import lombok.AllArgsConstructor;
-
 import java.util.List;
 import java.util.stream.Collectors;
 
-@AllArgsConstructor
 public class Feeds {
 
     private List<Feed> feeds;
+
+    public Feeds(List<Feed> feeds) {
+        this.feeds = feeds;
+    }
 
     public List<Feed> sortedByLikeCount(int limit) {
         return this.feeds.stream()

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Like.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Like.java
@@ -1,16 +1,17 @@
 package com.wooteco.nolto.feed.domain;
 
 import com.wooteco.nolto.user.domain.User;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.Objects;
 
-@Getter
-@NoArgsConstructor
-@Table(name = "Likes")
 @Entity
+@Table(name = "Likes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Like {
 
     @Id

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/CommentController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/CommentController.java
@@ -5,9 +5,11 @@ import com.wooteco.nolto.auth.UserAuthenticationPrincipal;
 import com.wooteco.nolto.auth.ValidTokenRequired;
 import com.wooteco.nolto.feed.application.CommentLikeService;
 import com.wooteco.nolto.feed.application.CommentService;
-import com.wooteco.nolto.feed.ui.dto.*;
+import com.wooteco.nolto.feed.ui.dto.CommentRequest;
+import com.wooteco.nolto.feed.ui.dto.CommentResponse;
+import com.wooteco.nolto.feed.ui.dto.ReplyResponse;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,9 +17,9 @@ import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
 
-@AllArgsConstructor
 @RestController
 @RequestMapping("/feeds/{feedId:[\\d]+}/comments")
+@RequiredArgsConstructor
 public class CommentController {
 
     private final CommentService commentService;
@@ -72,9 +74,9 @@ public class CommentController {
     @ValidTokenRequired
     @PostMapping("/{commentId:[\\d]+}/replies")
     public ResponseEntity<CommentResponse> createReply(@MemberAuthenticationPrincipal User user,
-                                                     @PathVariable Long feedId,
-                                                     @PathVariable Long commentId,
-                                                     @RequestBody @Valid CommentRequest request) {
+                                                       @PathVariable Long feedId,
+                                                       @PathVariable Long commentId,
+                                                       @RequestBody @Valid CommentRequest request) {
         CommentResponse replyResponse = commentService.createReply(user, feedId, commentId, request);
         return ResponseEntity
                 .created(URI.create("/feeds/" + feedId + "/comments/" + commentId + "/replies/" + replyResponse.getId()))

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/FeedController.java
@@ -10,7 +10,7 @@ import com.wooteco.nolto.feed.ui.dto.FeedCardResponse;
 import com.wooteco.nolto.feed.ui.dto.FeedRequest;
 import com.wooteco.nolto.feed.ui.dto.FeedResponse;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -25,10 +25,10 @@ import java.util.List;
 import static com.wooteco.nolto.ViewHistoryManager.isAlreadyView;
 import static com.wooteco.nolto.ViewHistoryManager.setCookieByReadHistory;
 
-@AllArgsConstructor
 @RestController
-@Validated
 @RequestMapping("/feeds")
+@Validated
+@RequiredArgsConstructor
 public class FeedController {
 
     private final FeedService feedService;

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/AuthorResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/AuthorResponse.java
@@ -1,15 +1,19 @@
 package com.wooteco.nolto.feed.ui.dto;
 
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
 @Getter
 public class AuthorResponse {
     private final Long id;
     private final String nickname;
     private final String imageUrl;
+
+    public AuthorResponse(Long id, String nickname, String imageUrl) {
+        this.id = id;
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+    }
 
     public static AuthorResponse of(User author) {
         return new AuthorResponse(author.getId(), author.getNickName(), author.getImageUrl());

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/CommentRequest.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/CommentRequest.java
@@ -1,6 +1,5 @@
 package com.wooteco.nolto.feed.ui.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,10 +9,14 @@ import javax.validation.constraints.NotBlank;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class CommentRequest {
 
     @NotBlank
     private String content;
     private boolean helper;
+
+    public CommentRequest(String content, boolean helper) {
+        this.content = content;
+        this.helper = helper;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/CommentResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/CommentResponse.java
@@ -2,7 +2,6 @@ package com.wooteco.nolto.feed.ui.dto;
 
 import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -10,7 +9,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@AllArgsConstructor
 public class CommentResponse {
 
     private Long id;
@@ -22,6 +20,18 @@ public class CommentResponse {
     private LocalDateTime createdAt;
     private boolean modified;
     private AuthorResponse author;
+
+    public CommentResponse(Long id, String content, boolean helper, int likes, boolean liked, boolean feedAuthor, LocalDateTime createdAt, boolean modified, AuthorResponse author) {
+        this.id = id;
+        this.content = content;
+        this.helper = helper;
+        this.likes = likes;
+        this.liked = liked;
+        this.feedAuthor = feedAuthor;
+        this.createdAt = createdAt;
+        this.modified = modified;
+        this.author = author;
+    }
 
     public static CommentResponse of(Comment comment, boolean isCommentLiked) {
         return new CommentResponse(

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardPaginationResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardPaginationResponse.java
@@ -1,18 +1,21 @@
 package com.wooteco.nolto.feed.ui.dto;
 
 import com.wooteco.nolto.feed.domain.Feed;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 import java.util.Objects;
 
 @Getter
-@AllArgsConstructor
 public class FeedCardPaginationResponse {
 
     private final List<FeedCardResponse> feeds;
     private final Long nextFeedId;
+
+    public FeedCardPaginationResponse(List<FeedCardResponse> feeds, Long nextFeedId) {
+        this.feeds = feeds;
+        this.nextFeedId = nextFeedId;
+    }
 
     public static FeedCardPaginationResponse of(List<Feed> findFeeds, Feed nextFeed) {
         List<FeedCardResponse> feedCardResponses = FeedCardResponse.toList(findFeeds);

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedCardResponse.java
@@ -1,7 +1,6 @@
 package com.wooteco.nolto.feed.ui.dto;
 
 import com.wooteco.nolto.feed.domain.Feed;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.Collection;
@@ -9,7 +8,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@AllArgsConstructor
 public class FeedCardResponse {
     private final AuthorResponse author;
     private final Long id;
@@ -18,6 +16,16 @@ public class FeedCardResponse {
     private final String step;
     private final boolean sos;
     private final String thumbnailUrl;
+
+    public FeedCardResponse(AuthorResponse author, Long id, String title, String content, String step, boolean sos, String thumbnailUrl) {
+        this.author = author;
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.step = step;
+        this.sos = sos;
+        this.thumbnailUrl = thumbnailUrl;
+    }
 
     public static FeedCardResponse of(Feed feed) {
         return new FeedCardResponse(

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedRequest.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedRequest.java
@@ -3,7 +3,6 @@ package com.wooteco.nolto.feed.ui.dto;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.Step;
 import com.wooteco.nolto.tech.domain.TechValid;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,7 +16,6 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class FeedRequest {
     @NotBlank(message = "제목은 빈 값일 수 없습니다.")
     private String title;
@@ -37,6 +35,17 @@ public class FeedRequest {
     private String storageUrl;
     private String deployedUrl;
     private MultipartFile thumbnailImage;
+
+    public FeedRequest(String title, List<Long> techs, String content, String step, boolean sos, String storageUrl, String deployedUrl, MultipartFile thumbnailImage) {
+        this.title = title;
+        this.techs = techs;
+        this.content = content;
+        this.step = step;
+        this.sos = sos;
+        this.storageUrl = storageUrl;
+        this.deployedUrl = deployedUrl;
+        this.thumbnailImage = thumbnailImage;
+    }
 
     public Feed toEntityWithThumbnailUrl(String thumbnailUrl) {
         return new Feed(

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedRequest.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedRequest.java
@@ -48,14 +48,14 @@ public class FeedRequest {
     }
 
     public Feed toEntityWithThumbnailUrl(String thumbnailUrl) {
-        return new Feed(
-                this.title,
-                this.content,
-                Step.of(step),
-                this.sos,
-                this.storageUrl,
-                this.deployedUrl,
-                thumbnailUrl
-        );
+        return Feed.builder()
+                .title(this.title)
+                .content(content)
+                .step(Step.of(step))
+                .isSos(this.sos)
+                .storageUrl(this.storageUrl)
+                .deployedUrl(this.deployedUrl)
+                .thumbnailUrl(thumbnailUrl)
+                .build();
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/FeedResponse.java
@@ -3,13 +3,11 @@ package com.wooteco.nolto.feed.ui.dto;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.tech.ui.dto.TechResponse;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-@AllArgsConstructor
 @Getter
 public class FeedResponse {
     private final AuthorResponse author;
@@ -26,6 +24,23 @@ public class FeedResponse {
     private final int views;
     private final boolean liked;
     private final LocalDateTime createdDate;
+
+    public FeedResponse(AuthorResponse author, Long id, String title, List<TechResponse> techs, String content, String step, boolean sos, String storageUrl, String deployedUrl, String thumbnailUrl, int likes, int views, boolean liked, LocalDateTime createdDate) {
+        this.author = author;
+        this.id = id;
+        this.title = title;
+        this.techs = techs;
+        this.content = content;
+        this.step = step;
+        this.sos = sos;
+        this.storageUrl = storageUrl;
+        this.deployedUrl = deployedUrl;
+        this.thumbnailUrl = thumbnailUrl;
+        this.likes = likes;
+        this.views = views;
+        this.liked = liked;
+        this.createdDate = createdDate;
+    }
 
     public static FeedResponse of(User author, Feed feed, boolean liked) {
         return new FeedResponse(AuthorResponse.of(author), feed.getId(), feed.getTitle(), TechResponse.toList(feed.getTechs()),

--- a/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/ReplyResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/ui/dto/ReplyResponse.java
@@ -2,7 +2,6 @@ package com.wooteco.nolto.feed.ui.dto;
 
 import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -10,7 +9,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@AllArgsConstructor
 public class ReplyResponse {
 
     private final Long id;
@@ -22,6 +20,18 @@ public class ReplyResponse {
     private final boolean modified;
     private final Long commentId;
     private final AuthorResponse author;
+
+    public ReplyResponse(Long id, String content, int likes, boolean liked, boolean feedAuthor, LocalDateTime createdAt, boolean modified, Long commentId, AuthorResponse author) {
+        this.id = id;
+        this.content = content;
+        this.likes = likes;
+        this.liked = liked;
+        this.feedAuthor = feedAuthor;
+        this.createdAt = createdAt;
+        this.modified = modified;
+        this.commentId = commentId;
+        this.author = author;
+    }
 
     public static ReplyResponse of(Comment reply, boolean liked) {
         return new ReplyResponse(

--- a/backend/src/main/java/com/wooteco/nolto/image/application/ImageService.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/application/ImageService.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.exception.InternalServerErrorException;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,7 @@ import java.util.UUID;
 
 @Transactional
 @Service
+@RequiredArgsConstructor
 public class ImageService {
 
     public static final String FILENAME_EXTENSION_DOT = ".";
@@ -33,11 +35,6 @@ public class ImageService {
 
     private final AmazonS3 amazonS3Client;
     private final ImageResizeService imageResizeService;
-
-    public ImageService(AmazonS3 amazonS3Client, ImageResizeService imageResizeService) {
-        this.amazonS3Client = amazonS3Client;
-        this.imageResizeService = imageResizeService;
-    }
 
     public String upload(MultipartFile multipartFile, ImageKind imageKind) {
         if (isEmpty(multipartFile)) {

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationCommentDeleteEvent.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationCommentDeleteEvent.java
@@ -1,11 +1,14 @@
 package com.wooteco.nolto.notification.application;
 
 import com.wooteco.nolto.feed.domain.Comment;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class NotificationCommentDeleteEvent {
+
     private final Comment comment;
+
+    public NotificationCommentDeleteEvent(Comment comment) {
+        this.comment = comment;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEvent.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEvent.java
@@ -5,10 +5,8 @@ import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.notification.domain.Notification;
 import com.wooteco.nolto.notification.domain.NotificationType;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor
 @Getter
 public class NotificationEvent {
     private final User listener;
@@ -16,6 +14,14 @@ public class NotificationEvent {
     private final Comment comment;
     private final User publisher;
     private final NotificationType notificationType;
+
+    public NotificationEvent(User listener, Feed feed, Comment comment, User publisher, NotificationType notificationType) {
+        this.listener = listener;
+        this.feed = feed;
+        this.comment = comment;
+        this.publisher = publisher;
+        this.notificationType = notificationType;
+    }
 
     public Notification toEntity() {
         return new Notification(listener, feed, comment, publisher, notificationType);

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEventHandler.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationEventHandler.java
@@ -1,12 +1,12 @@
 package com.wooteco.nolto.notification.application;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class NotificationEventHandler {
 
     private final NotificationService notificationService;

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationFeedDeleteEvent.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationFeedDeleteEvent.java
@@ -1,11 +1,13 @@
 package com.wooteco.nolto.notification.application;
 
 import com.wooteco.nolto.feed.domain.Feed;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class NotificationFeedDeleteEvent {
     private Feed feed;
+
+    public NotificationFeedDeleteEvent(Feed feed) {
+        this.feed = feed;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
@@ -8,7 +8,7 @@ import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.notification.domain.Notification;
 import com.wooteco.nolto.notification.domain.NotificationRepository;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +17,7 @@ import java.util.List;
 
 @Service
 @Transactional
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;

--- a/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/application/NotificationService.java
@@ -15,8 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@Service
 @Transactional
+@Service
 @RequiredArgsConstructor
 public class NotificationService {
 

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
@@ -5,6 +5,7 @@ import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.user.domain.User;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,16 +40,13 @@ public class Notification extends BaseEntity {
     @NotNull
     private NotificationType notificationType;
 
-    public Notification(Long id, User listener, Feed feed, Comment comment, User publisher, NotificationType notificationType) {
-        this.id = id;
-        this.listener = listener;
-        this.feed = feed;
-        this.comment = comment;
-        this.publisher = publisher;
-        this.notificationType = notificationType;
+    public Notification(User listener, Feed feed, Comment comment, User publisher, NotificationType notificationType) {
+        this(null, listener, feed, comment, publisher, notificationType);
     }
 
-    public Notification(User listener, Feed feed, Comment comment, User publisher, NotificationType notificationType) {
+    @Builder
+    public Notification(Long id, User listener, Feed feed, Comment comment, User publisher, NotificationType notificationType) {
+        this.id = id;
         this.listener = listener;
         this.feed = feed;
         this.comment = comment;

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
@@ -4,6 +4,7 @@ import com.wooteco.nolto.BaseEntity;
 import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.user.domain.User;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,7 +13,7 @@ import javax.validation.constraints.NotNull;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
+++ b/backend/src/main/java/com/wooteco/nolto/notification/domain/Notification.java
@@ -4,7 +4,6 @@ import com.wooteco.nolto.BaseEntity;
 import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,9 +11,8 @@ import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
 @Entity
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
+@NoArgsConstructor
 public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,6 +37,15 @@ public class Notification extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @NotNull
     private NotificationType notificationType;
+
+    public Notification(Long id, User listener, Feed feed, Comment comment, User publisher, NotificationType notificationType) {
+        this.id = id;
+        this.listener = listener;
+        this.feed = feed;
+        this.comment = comment;
+        this.publisher = publisher;
+        this.notificationType = notificationType;
+    }
 
     public Notification(User listener, Feed feed, Comment comment, User publisher, NotificationType notificationType) {
         this.listener = listener;

--- a/backend/src/main/java/com/wooteco/nolto/tech/application/TechService.java
+++ b/backend/src/main/java/com/wooteco/nolto/tech/application/TechService.java
@@ -3,7 +3,7 @@ package com.wooteco.nolto.tech.application;
 import com.wooteco.nolto.tech.domain.Tech;
 import com.wooteco.nolto.tech.domain.TechRepository;
 import com.wooteco.nolto.tech.ui.dto.TechResponse;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 
 @Transactional
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class TechService {
 
     private static final String TECH_SEARCH_DELIMITER = ",";

--- a/backend/src/main/java/com/wooteco/nolto/tech/domain/Tech.java
+++ b/backend/src/main/java/com/wooteco/nolto/tech/domain/Tech.java
@@ -1,6 +1,7 @@
 package com.wooteco.nolto.tech.domain;
 
 import com.wooteco.nolto.feed.domain.FeedTech;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,9 +11,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-@Getter
-@NoArgsConstructor
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Tech {
 
     @Id

--- a/backend/src/main/java/com/wooteco/nolto/tech/ui/TechController.java
+++ b/backend/src/main/java/com/wooteco/nolto/tech/ui/TechController.java
@@ -2,7 +2,7 @@ package com.wooteco.nolto.tech.ui;
 
 import com.wooteco.nolto.tech.application.TechService;
 import com.wooteco.nolto.tech.ui.dto.TechResponse;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,10 +13,10 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/tags/techs")
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class TechController {
 
-    private TechService techService;
+    private final TechService techService;
 
     @GetMapping
     public ResponseEntity<List<TechResponse>> findByTechsContains(@RequestParam("auto_complete") String searchWord) {

--- a/backend/src/main/java/com/wooteco/nolto/tech/ui/dto/TechResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/tech/ui/dto/TechResponse.java
@@ -1,17 +1,20 @@
 package com.wooteco.nolto.tech.ui.dto;
 
 import com.wooteco.nolto.tech.domain.Tech;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@AllArgsConstructor
 public class TechResponse {
     private final Long id;
     private final String text;
+
+    public TechResponse(Long id, String text) {
+        this.id = id;
+        this.text = text;
+    }
 
     public static List<TechResponse> toList(List<Tech> techs) {
         return techs.stream()

--- a/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
@@ -10,7 +10,7 @@ import com.wooteco.nolto.notification.domain.Notification;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
 import com.wooteco.nolto.user.ui.dto.*;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +21,7 @@ import static com.wooteco.nolto.exception.ErrorType.ALREADY_EXIST_NICKNAME;
 
 @Service
 @Transactional
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class MemberService {
 
     private final ImageService imageService;

--- a/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/application/MemberService.java
@@ -19,8 +19,8 @@ import java.util.List;
 
 import static com.wooteco.nolto.exception.ErrorType.ALREADY_EXIST_NICKNAME;
 
-@Service
 @Transactional
+@Service
 @RequiredArgsConstructor
 public class MemberService {
 

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -8,6 +8,7 @@ import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.feed.domain.CommentLike;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.Like;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,7 +22,7 @@ import java.util.stream.Collectors;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
     public static final GuestUser GUEST_USER = new GuestUser();
 

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -19,10 +19,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+@Entity
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
-@Entity
 public class User extends BaseEntity {
     public static final GuestUser GUEST_USER = new GuestUser();
 
@@ -58,6 +57,15 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<CommentLike> commentLikes = new ArrayList<>();
+
+    public User(Long id, String socialId, SocialType socialType, String nickName, String imageUrl, String bio) {
+        this.id = id;
+        this.socialId = socialId;
+        this.socialType = socialType;
+        this.nickName = nickName;
+        this.imageUrl = imageUrl;
+        this.bio = bio;
+    }
 
     public User(Long id, String socialId, SocialType socialType, String nickName) {
         this(id, socialId, socialType, nickName, null, "");

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -9,7 +9,7 @@ import com.wooteco.nolto.feed.domain.CommentLike;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.Like;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -48,17 +48,22 @@ public class User extends BaseEntity {
     private String bio = "";
 
     @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
-    private final List<Feed> feeds = new ArrayList<>();
+    private List<Feed> feeds = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private final List<Like> likes = new ArrayList<>();
+    private List<Like> likes = new ArrayList<>();
 
     @OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<Comment> comments = new ArrayList<>();
+    private List<Comment> comments = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private final List<CommentLike> commentLikes = new ArrayList<>();
+    private List<CommentLike> commentLikes = new ArrayList<>();
 
+    public User(String socialId, SocialType socialType, String nickName, String imageUrl) {
+        this(null, socialId, socialType, nickName, imageUrl, "");
+    }
+
+    @Builder
     public User(Long id, String socialId, SocialType socialType, String nickName, String imageUrl, String bio) {
         this.id = id;
         this.socialId = socialId;
@@ -66,18 +71,10 @@ public class User extends BaseEntity {
         this.nickName = nickName;
         this.imageUrl = imageUrl;
         this.bio = bio;
-    }
-
-    public User(Long id, String socialId, SocialType socialType, String nickName) {
-        this(id, socialId, socialType, nickName, null, "");
-    }
-
-    public User(String socialId, SocialType socialType, String nickName, String imageUrl) {
-        this(null, socialId, socialType, nickName, imageUrl, "");
-    }
-
-    public User(Long id, String socialId, SocialType socialType, String nickName, String imageUrl) {
-        this(id, socialId, socialType, nickName, imageUrl, "");
+        this.feeds = new ArrayList<>();
+        this.likes  = new ArrayList<>();
+        this.comments = new ArrayList<>();
+        this.commentLikes = new ArrayList<>();
     }
 
     public void update(String nickName, String imageUrl) {

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/MemberController.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/MemberController.java
@@ -2,11 +2,10 @@ package com.wooteco.nolto.user.ui;
 
 import com.wooteco.nolto.auth.MemberAuthenticationPrincipal;
 import com.wooteco.nolto.auth.ValidTokenRequired;
-import com.wooteco.nolto.notification.application.NotificationService;
 import com.wooteco.nolto.user.application.MemberService;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.ui.dto.*;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,7 +14,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/members/me")
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/CommentHistoryResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/CommentHistoryResponse.java
@@ -1,17 +1,20 @@
 package com.wooteco.nolto.user.ui.dto;
 
 import com.wooteco.nolto.feed.domain.Comment;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@AllArgsConstructor
 public class CommentHistoryResponse {
     private final FeedHistoryResponse feed;
     private final String text;
+
+    public CommentHistoryResponse(FeedHistoryResponse feed, String text) {
+        this.feed = feed;
+        this.text = text;
+    }
 
     public static CommentHistoryResponse of(Comment comment) {
         return new CommentHistoryResponse(FeedHistoryResponse.of(comment.getFeed()), comment.getContent());

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/CommentNotificationResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/CommentNotificationResponse.java
@@ -1,17 +1,20 @@
 package com.wooteco.nolto.user.ui.dto;
 
 import com.wooteco.nolto.feed.domain.Comment;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.Objects;
 
 @Getter
-@AllArgsConstructor
 public class CommentNotificationResponse {
 
     private final Long id;
     private final String text;
+
+    public CommentNotificationResponse(Long id, String text) {
+        this.id = id;
+        this.text = text;
+    }
 
     public static CommentNotificationResponse of(Comment comment) {
         if (Objects.isNull(comment)) {

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/FeedHistoryResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/FeedHistoryResponse.java
@@ -1,14 +1,12 @@
 package com.wooteco.nolto.user.ui.dto;
 
 import com.wooteco.nolto.feed.domain.Feed;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@AllArgsConstructor
 public class FeedHistoryResponse {
     private final Long id;
     private final String title;
@@ -16,6 +14,15 @@ public class FeedHistoryResponse {
     private final String step;
     private final boolean sos;
     private final String thumbnailUrl;
+
+    public FeedHistoryResponse(Long id, String title, String content, String step, boolean sos, String thumbnailUrl) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.step = step;
+        this.sos = sos;
+        this.thumbnailUrl = thumbnailUrl;
+    }
 
     public static FeedHistoryResponse of(Feed feed) {
         return new FeedHistoryResponse(

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/FeedNotificationResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/FeedNotificationResponse.java
@@ -1,15 +1,18 @@
 package com.wooteco.nolto.user.ui.dto;
 
 import com.wooteco.nolto.feed.domain.Feed;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class FeedNotificationResponse {
 
     private final Long id;
     private final String title;
+
+    public FeedNotificationResponse(Long id, String title) {
+        this.id = id;
+        this.title = title;
+    }
 
     public static FeedNotificationResponse of(Feed feed) {
         return new FeedNotificationResponse(feed.getId(), feed.getTitle());

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/MemberHistoryResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/MemberHistoryResponse.java
@@ -2,17 +2,21 @@ package com.wooteco.nolto.user.ui.dto;
 
 import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.feed.domain.Feed;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
 public class MemberHistoryResponse {
     private final List<FeedHistoryResponse> likedFeeds;
     private final List<FeedHistoryResponse> myFeeds;
     private final List<CommentHistoryResponse> myComments;
+
+    public MemberHistoryResponse(List<FeedHistoryResponse> likedFeeds, List<FeedHistoryResponse> myFeeds, List<CommentHistoryResponse> myComments) {
+        this.likedFeeds = likedFeeds;
+        this.myFeeds = myFeeds;
+        this.myComments = myComments;
+    }
 
     public static MemberHistoryResponse of(List<Feed> likedFeeds, List<Feed> myFeeds, List<Comment> myComments) {
         return new MemberHistoryResponse(

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/MemberResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/MemberResponse.java
@@ -1,16 +1,21 @@
 package com.wooteco.nolto.user.ui.dto;
 
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class MemberResponse {
     private final Long id;
     private final String nickname;
     private final String imageUrl;
     private final long notifications;
+
+    public MemberResponse(Long id, String nickname, String imageUrl, long notifications) {
+        this.id = id;
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+        this.notifications = notifications;
+    }
 
     public static MemberResponse of(User user, long notificationCount) {
         return new MemberResponse(user.getId(), user.getNickName(), user.getImageUrl(), notificationCount);

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/NicknameValidationResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/NicknameValidationResponse.java
@@ -1,6 +1,5 @@
 package com.wooteco.nolto.user.ui.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,7 +7,10 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class NicknameValidationResponse {
     private boolean isIsUsable;
+
+    public NicknameValidationResponse(boolean isIsUsable) {
+        this.isIsUsable = isIsUsable;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/NotificationResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/NotificationResponse.java
@@ -2,14 +2,12 @@ package com.wooteco.nolto.user.ui.dto;
 
 import com.wooteco.nolto.feed.ui.dto.AuthorResponse;
 import com.wooteco.nolto.notification.domain.Notification;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@AllArgsConstructor
 public class NotificationResponse {
 
     private final Long id;
@@ -17,6 +15,14 @@ public class NotificationResponse {
     private final FeedNotificationResponse feed;
     private final CommentNotificationResponse comment;
     private final String type;
+
+    public NotificationResponse(Long id, AuthorResponse user, FeedNotificationResponse feed, CommentNotificationResponse comment, String type) {
+        this.id = id;
+        this.user = user;
+        this.feed = feed;
+        this.comment = comment;
+        this.type = type;
+    }
 
     public static List<NotificationResponse> toList(List<Notification> notifications) {
         return notifications.stream()

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/ProfileRequest.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/ProfileRequest.java
@@ -1,6 +1,5 @@
 package com.wooteco.nolto.user.ui.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,11 +11,16 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 public class ProfileRequest {
     @NotBlank
     private String nickname;
     @NotNull
     private String bio = "";
     private MultipartFile image;
+
+    public ProfileRequest(String nickname, String bio, MultipartFile image) {
+        this.nickname = nickname;
+        this.bio = bio;
+        this.image = image;
+    }
 }

--- a/backend/src/main/java/com/wooteco/nolto/user/ui/dto/ProfileResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/ui/dto/ProfileResponse.java
@@ -1,15 +1,13 @@
 package com.wooteco.nolto.user.ui.dto;
 
 import com.wooteco.nolto.user.domain.User;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-@Setter
 @Getter
-@AllArgsConstructor
+@Setter
 public class ProfileResponse {
     private Long id;
     private String nickname;
@@ -17,6 +15,15 @@ public class ProfileResponse {
     private String imageUrl;
     private long notifications;
     private LocalDateTime createdAt;
+
+    public ProfileResponse(Long id, String nickname, String bio, String imageUrl, long notifications, LocalDateTime createdAt) {
+        this.id = id;
+        this.nickname = nickname;
+        this.bio = bio;
+        this.imageUrl = imageUrl;
+        this.notifications = notifications;
+        this.createdAt = createdAt;
+    }
 
     public static ProfileResponse of(User user, long notifications) {
         return new ProfileResponse(user.getId(), user.getNickName(), user.getBio(), user.getImageUrl(),

--- a/backend/src/test/java/com/wooteco/nolto/BaseEntityTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/BaseEntityTest.java
@@ -42,12 +42,33 @@ class BaseEntityTest {
         userRepository.save(user1);
         userRepository.save(user2);
 
-        feed1 = new Feed("title1", "content1", Step.PROGRESS, true,
-                "storageUrl", "", "http://thumbnailUrl.ppnngg");
-        feed2 = new Feed("title2", "content2", Step.PROGRESS, false,
-                "", "deployUrl", "http://thumbnailUrl.pnggg");
-        feed3 = new Feed("title3", "content3", Step.COMPLETE, false,
-                "storageUrl", "deployUrl", "http://thumbnailUrl.ddd");
+        feed1 = Feed.builder()
+                .title("title1")
+                .content("content1")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("storageUrl")
+                .thumbnailUrl("http://thumbnailUrl.png")
+                .build();
+
+        feed2 = Feed.builder()
+                .title("title2")
+                .content("content2")
+                .step(Step.PROGRESS)
+                .isSos(false)
+                .deployedUrl("deployUrl")
+                .thumbnailUrl("http://thumbnailUrl.png")
+                .build();
+
+        feed3 = Feed.builder()
+                .title("title3")
+                .content("content3")
+                .step(Step.COMPLETE)
+                .isSos(false)
+                .storageUrl("storageUrl")
+                .deployedUrl("deployUrl")
+                .thumbnailUrl("http://thumbnailUrl.png")
+                .build();
 
         feed1.writtenBy(user1);
         feed2.writtenBy(user2);
@@ -71,7 +92,7 @@ class BaseEntityTest {
 
     @DisplayName("데이터 변경 시 lastModifiedDate가 수정된다")
     @Test
-    void update() throws InterruptedException {
+    void update() {
         // given
         Feed savedFeed2 = feedRepository.save(feed2);
         LocalDateTime modifiedDate = savedFeed2.getModifiedDate(); // 생성 시점
@@ -89,7 +110,7 @@ class BaseEntityTest {
 
     @DisplayName("객체가 수정됐는지 확인할 수 있다.")
     @Test
-    void isModified() throws InterruptedException {
+    void isModified() {
         // given
         feed1.update("수정된 제목", feed1.getContent(), feed1.getStep(), feed1.isSos(), feed1.getStorageUrl(), feed1.getDeployedUrl());
 

--- a/backend/src/test/java/com/wooteco/nolto/acceptance/TechAcceptanceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/acceptance/TechAcceptanceTest.java
@@ -155,8 +155,15 @@ class TechAcceptanceTest extends AcceptanceTest {
 
     private void setUpFeedAndFeedTech() {
         User user = new User("1L", SocialType.GOOGLE, "JOEL", "imageUrl");
-        Feed feed = new Feed("title", "content", Step.PROGRESS, true, "storageUrl",
-                "", "http://thumbnailUrl.png").writtenBy(user);
+        Feed feed = Feed.builder().title("title")
+                .content("content")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("storageUrl")
+                .thumbnailUrl("http://thumbnailUrl.png")
+                .build()
+        .writtenBy(user);
+
         userRepository.save(user);
         feedRepository.save(feed);
         feedTechRepository.saveAll(Arrays.asList(new FeedTech(feed, JAVA), new FeedTech(feed, JAVASCRIPT),

--- a/backend/src/test/java/com/wooteco/nolto/api/CommentControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/CommentControllerTest.java
@@ -1,10 +1,12 @@
 package com.wooteco.nolto.api;
 
-import com.wooteco.nolto.auth.domain.SocialType;
 import com.wooteco.nolto.feed.application.CommentLikeService;
 import com.wooteco.nolto.feed.application.CommentService;
 import com.wooteco.nolto.feed.ui.CommentController;
-import com.wooteco.nolto.feed.ui.dto.*;
+import com.wooteco.nolto.feed.ui.dto.AuthorResponse;
+import com.wooteco.nolto.feed.ui.dto.CommentRequest;
+import com.wooteco.nolto.feed.ui.dto.CommentResponse;
+import com.wooteco.nolto.feed.ui.dto.ReplyResponse;
 import com.wooteco.nolto.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,12 +34,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = CommentController.class)
-public class CommentControllerTest extends ControllerTest {
+class CommentControllerTest extends ControllerTest {
 
     private static final String BEARER = "Bearer ";
     private static final String ACCESS_TOKEN = "accessToken";
-    private static final User LOGIN_USER =
-            new User(1L, "11111L", SocialType.GITHUB, "유저", "imageUrl");
 
     private static final long FEED_ID = 1L;
     private static final long COMMENT_ID = 2L;
@@ -114,9 +114,9 @@ public class CommentControllerTest extends ControllerTest {
         given(commentService.createComment(any(User.class), any(Long.class), any(CommentRequest.class))).willReturn(COMMENT_RESPONSE);
 
         mockMvc.perform(post("/feeds/{feedId}/comments", FEED_ID)
-                        .header("Authorization", BEARER + ACCESS_TOKEN)
-                        .content(new ObjectMapper().writeValueAsString(new CommentRequest("작성된 댓글입니다.", false)))
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .header("Authorization", BEARER + ACCESS_TOKEN)
+                .content(new ObjectMapper().writeValueAsString(new CommentRequest("작성된 댓글입니다.", false)))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isCreated())
                 .andExpect(content().json(objectMapper.writeValueAsString(COMMENT_RESPONSE)))
                 .andDo(document("comment-create",
@@ -154,9 +154,9 @@ public class CommentControllerTest extends ControllerTest {
         given(commentService.updateComment(any(Long.class), any(CommentRequest.class), any(User.class))).willReturn(UPDATED_COMMENT_RESPONSE1);
 
         mockMvc.perform(patch("/feeds/{feedId}/comments/{commentId}", FEED_ID, COMMENT_ID)
-                        .header(HttpHeaders.AUTHORIZATION, BEARER + ACCESS_TOKEN)
-                        .content(new ObjectMapper().writeValueAsString(updateRequest))
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .header(HttpHeaders.AUTHORIZATION, BEARER + ACCESS_TOKEN)
+                .content(new ObjectMapper().writeValueAsString(updateRequest))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(UPDATED_COMMENT_RESPONSE1)))
                 .andDo(document("comment-update",
@@ -192,7 +192,7 @@ public class CommentControllerTest extends ControllerTest {
         given(authService.findUserByToken(ACCESS_TOKEN)).willReturn(LOGIN_USER);
 
         mockMvc.perform(delete("/feeds/{feedId}/comments/{commentId}", FEED_ID, COMMENT_ID)
-                        .header(HttpHeaders.AUTHORIZATION, BEARER + ACCESS_TOKEN))
+                .header(HttpHeaders.AUTHORIZATION, BEARER + ACCESS_TOKEN))
                 .andExpect(status().isNoContent())
                 .andDo(document("comment-delete",
                         getDocumentRequest(),
@@ -212,10 +212,10 @@ public class CommentControllerTest extends ControllerTest {
         given(commentService.findAllByFeedId(any(Long.class), any(User.class))).willReturn(responses);
 
         mockMvc.perform(
-                        get("/feeds/{feedId}/comments", FEED_ID)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON)
-                                .header("Authorization", "Bearer " + ACCESS_TOKEN))
+                get("/feeds/{feedId}/comments", FEED_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(responses)))
                 .andDo(document("comment-findAllCommentsByFeedId",
@@ -237,7 +237,7 @@ public class CommentControllerTest extends ControllerTest {
         given(authService.findUserByToken(ACCESS_TOKEN)).willReturn(LOGIN_USER);
 
         mockMvc.perform(post("/feeds/{feedId}/comments/{commentId}/like", FEED_ID, COMMENT_ID)
-                        .header("Authorization", "Bearer " + ACCESS_TOKEN))
+                .header("Authorization", "Bearer " + ACCESS_TOKEN))
                 .andExpect(status().isOk())
                 .andDo(document("comment-addLike",
                         getDocumentRequest(),
@@ -254,7 +254,7 @@ public class CommentControllerTest extends ControllerTest {
         given(authService.findUserByToken(ACCESS_TOKEN)).willReturn(LOGIN_USER);
 
         mockMvc.perform(post("/feeds/{feedId}/comments/{commentId}/unlike", FEED_ID, COMMENT_ID)
-                        .header("Authorization", "Bearer " + ACCESS_TOKEN))
+                .header("Authorization", "Bearer " + ACCESS_TOKEN))
                 .andExpect(status().isOk())
                 .andDo(document("comment-deleteLike",
                         getDocumentRequest(),
@@ -272,9 +272,9 @@ public class CommentControllerTest extends ControllerTest {
         given(commentService.createReply(any(User.class), any(Long.class), any(Long.class), any())).willReturn(COMMENT_REPLY_RESPONSE);
 
         mockMvc.perform(post("/feeds/{feedId}/comments/{commentId}/replies", FEED_ID, COMMENT_ID)
-                        .header(HttpHeaders.AUTHORIZATION, BEARER + ACCESS_TOKEN)
-                        .content(new ObjectMapper().writeValueAsString(new CommentRequest("작성된 대댓글입니다.", false)))
-                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .header(HttpHeaders.AUTHORIZATION, BEARER + ACCESS_TOKEN)
+                .content(new ObjectMapper().writeValueAsString(new CommentRequest("작성된 대댓글입니다.", false)))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isCreated())
                 .andExpect(content().json(objectMapper.writeValueAsString(COMMENT_REPLY_RESPONSE)))
                 .andDo(document("reply-create",
@@ -320,10 +320,10 @@ public class CommentControllerTest extends ControllerTest {
         given(commentService.findAllRepliesById(any(User.class), any(Long.class), any())).willReturn(replyResponses);
 
         mockMvc.perform(
-                        get("/feeds/{feedId}/comments/{commentId}/replies", FEED_ID, COMMENT_ID)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON)
-                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN))
+                get("/feeds/{feedId}/comments/{commentId}/replies", FEED_ID, COMMENT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ACCESS_TOKEN))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(replyResponses)))
                 .andDo(document("reply-findAllReplies",

--- a/backend/src/test/java/com/wooteco/nolto/api/ControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/ControllerTest.java
@@ -2,6 +2,8 @@ package com.wooteco.nolto.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wooteco.nolto.auth.application.AuthService;
+import com.wooteco.nolto.auth.domain.SocialType;
+import com.wooteco.nolto.user.domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -23,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 @ActiveProfiles("test")
 @AutoConfigureRestDocs
 @MockBean(JpaMetamodelMappingContext.class)
-public class ControllerTest {
+public abstract class ControllerTest {
     @Autowired
     private WebApplicationContext wac;
 
@@ -37,6 +39,15 @@ public class ControllerTest {
     public AuthService authService;
 
     public MockMvc mockMvc;
+
+    public static final User LOGIN_USER = User.builder()
+            .id(1L)
+            .socialId("SOCIAL_ID")
+            .socialType(SocialType.GITHUB)
+            .nickName("NICKNAME")
+            .imageUrl("IMAGE")
+            .bio("BIO")
+            .build();
 
     @BeforeEach
     void setUp() {

--- a/backend/src/test/java/com/wooteco/nolto/api/FeedControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/FeedControllerTest.java
@@ -26,7 +26,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -55,11 +54,29 @@ public class FeedControllerTest extends ControllerTest {
 
     private static final long FEED_ID = 1L;
 
-    public static final Feed FEED1 =
-            new Feed(1L, "title1", "content1", Step.PROGRESS, true, "www.surl.com", "www.durl.com", "www.turl.com").writtenBy(LOGIN_USER);
+    public static final Feed FEED1 = Feed.builder()
+            .id(1L)
+            .title("title")
+            .content("난 너무 잘해")
+            .step(Step.PROGRESS)
+            .isSos(true)
+            .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .deployedUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build()
+            .writtenBy(LOGIN_USER);
 
-    public static final Feed FEED2 =
-            new Feed(2L, "title2", "content2", Step.COMPLETE, false, "", "http://woowa.jofilm.com", "", 2, LOGIN_USER, new ArrayList<>());
+    public static final Feed FEED2 = Feed.builder()
+            .id(2L)
+            .title("title")
+            .content("난 너무 잘해")
+            .step(Step.COMPLETE)
+            .isSos(false)
+            .deployedUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .views(2)
+            .author(LOGIN_USER)
+            .build();
 
     private static final List<FeedCardResponse> FEED_CARD_RESPONSES = FeedCardResponse.toList(Arrays.asList(FEED1, FEED2));
 

--- a/backend/src/test/java/com/wooteco/nolto/api/FeedControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/FeedControllerTest.java
@@ -1,6 +1,5 @@
 package com.wooteco.nolto.api;
 
-import com.wooteco.nolto.auth.domain.SocialType;
 import com.wooteco.nolto.feed.application.FeedService;
 import com.wooteco.nolto.feed.application.LikeService;
 import com.wooteco.nolto.feed.domain.Feed;
@@ -42,12 +41,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = FeedController.class)
-public class FeedControllerTest extends ControllerTest {
+class FeedControllerTest extends ControllerTest {
 
     private static final String ACCESS_TOKEN = "accessToken";
     private static final String ACCESS_TOKEN_OPTIONAL = "accessTokenOptional";
-    private static final User LOGIN_USER =
-            new User(2L, "11111L", SocialType.GITHUB, "아마찌", "imageUrl");
 
     private static final MockMultipartFile MOCK_MULTIPART_FILE =
             new MockMultipartFile("thumbnailImage", "thumbnailImage.png", "image/png", "<<png data>>".getBytes());

--- a/backend/src/test/java/com/wooteco/nolto/api/MemberControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/MemberControllerTest.java
@@ -1,6 +1,5 @@
 package com.wooteco.nolto.api;
 
-import com.wooteco.nolto.auth.domain.SocialType;
 import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.notification.domain.Notification;
@@ -41,8 +40,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class MemberControllerTest extends ControllerTest {
 
     private static final String ACCESS_TOKEN = "accessToken";
-    private static final User LOGIN_USER =
-            new User(1L, "11111", SocialType.GOOGLE, "아마찌", "imageUrl", "");
 
     private static final long NOTIFICATIONS = 0L;
     private static final long NOTIFICATION_ID = 1L;

--- a/backend/src/test/java/com/wooteco/nolto/api/OAuthControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/OAuthControllerTest.java
@@ -1,10 +1,8 @@
 package com.wooteco.nolto.api;
 
-import com.wooteco.nolto.auth.domain.SocialType;
 import com.wooteco.nolto.auth.ui.OAuthController;
 import com.wooteco.nolto.auth.ui.dto.OAuthRedirectResponse;
 import com.wooteco.nolto.auth.ui.dto.TokenResponse;
-import com.wooteco.nolto.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -21,12 +19,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = OAuthController.class)
-public class OAuthControllerTest extends ControllerTest {
+class OAuthControllerTest extends ControllerTest {
 
     private static final OAuthRedirectResponse OAUTH_REDIRECT_RESPONSE = new OAuthRedirectResponse("client_id", "redirect_uri", "scope", "response_type");
     private static final TokenResponse TOKEN_RESPONSE =
             new TokenResponse("eefaccesstoken123");
-    private static final User USER = new User("socialId", SocialType.GITHUB, "user", "imageUrl");
     private static final String SOCIAL_TYPE_NAME = "github";
     private static final String CODE = "code";
 

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceFixture.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceFixture.java
@@ -55,14 +55,6 @@ public class CommentServiceFixture {
         userRepository.saveAndFlush(찰리);
         userRepository.saveAndFlush(포모);
 
-//        찰리가_쓴_피드 = new Feed(
-//                "title",
-//                "content",
-//                Step.PROGRESS,
-//                true,
-//                "https://github.com/woowacourse-teams/2021-nolto",
-//                "https://github.com/woowacourse-teams/2021-nolto",
-//                "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png").writtenBy(찰리);
         찰리가_쓴_피드 = Feed.builder()
                 .title("title")
                 .content("content")
@@ -77,7 +69,6 @@ public class CommentServiceFixture {
 
         찰리가_쓴_피드에_찰리가_쓴_댓글 = new Comment("첫 댓글", false).writtenBy(찰리, 찰리가_쓴_피드);
         commentRepository.saveAndFlush(찰리가_쓴_피드에_찰리가_쓴_댓글);
-//        Thread.sleep(1);
         찰리가_쓴_피드에_포모가_쓴_댓글 = new Comment("두 번째 댓글", true).writtenBy(포모, 찰리가_쓴_피드);
         commentRepository.saveAndFlush(찰리가_쓴_피드에_포모가_쓴_댓글);
         찰리가_쓴_피드에_찰리가_쓴_댓글에_찰리가_쓴_대댓글 = new Comment("첫 대댓글", false).writtenBy(찰리, 찰리가_쓴_피드);

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceFixture.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceFixture.java
@@ -55,14 +55,24 @@ public class CommentServiceFixture {
         userRepository.saveAndFlush(찰리);
         userRepository.saveAndFlush(포모);
 
-        찰리가_쓴_피드 = new Feed(
-                "title",
-                "content",
-                Step.PROGRESS,
-                true,
-                "https://github.com/woowacourse-teams/2021-nolto",
-                "https://github.com/woowacourse-teams/2021-nolto",
-                "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png").writtenBy(찰리);
+//        찰리가_쓴_피드 = new Feed(
+//                "title",
+//                "content",
+//                Step.PROGRESS,
+//                true,
+//                "https://github.com/woowacourse-teams/2021-nolto",
+//                "https://github.com/woowacourse-teams/2021-nolto",
+//                "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png").writtenBy(찰리);
+        찰리가_쓴_피드 = Feed.builder()
+                .title("title")
+                .content("content")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+                .deployedUrl("https://github.com/woowacourse-teams/2021-nolto")
+                .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+                .build()
+                .writtenBy(찰리);
         feedRepository.saveAndFlush(찰리가_쓴_피드);
 
         찰리가_쓴_피드에_찰리가_쓴_댓글 = new Comment("첫 댓글", false).writtenBy(찰리, 찰리가_쓴_피드);

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
@@ -39,15 +39,17 @@ class CommentServiceTest extends CommentServiceFixture {
     private User 조엘 = new User("socialId", SocialType.GITHUB, "조엘", "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png");
     private User 포모1 = new User("socialId", SocialType.GOOGLE, "포모1", "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png");
 
-    private Feed 아마찌의_개쩌는_지하철_미션 = new Feed(
-            "아마찌의 개쩌는 지하철 미션",
-            "난 너무 잘해",
-            Step.COMPLETE,
-            false,
-            "www.github.com/newWisdom",
-            "www.github.com/newWisdom",
-            "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png"
-    );
+    private Feed 아마찌의_개쩌는_지하철_미션 = Feed.builder()
+            .title("아마찌의 개쩌는 지하철 미션")
+            .content("난 너무 잘해")
+            .step(Step.COMPLETE)
+            .isSos(false)
+            .storageUrl("www.github.com/newWisdom")
+            .deployedUrl("www.github.com/newWisdom")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build()
+            .writtenBy(찰리1);
+
 
     @BeforeEach
     void setUp() throws InterruptedException {

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/FeedTechServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/FeedTechServiceTest.java
@@ -54,9 +54,31 @@ class FeedTechServiceTest {
         user = new User("socialId", SocialType.GOOGLE, "nickName", "imageUrl");
         userRepository.save(user);
 
-        feed1 = new Feed("T1", "C1", Step.PROGRESS, true, "", "", "");
-        feed2 = new Feed("T2", "C2", Step.PROGRESS, true, "", "", "");
-        feed3 = new Feed("T3", "C3", Step.PROGRESS, true, "", "", "");
+        feed1 = Feed.builder()
+                .title("T1")
+                .content("C1")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("www.github.com/newWisdom")
+                .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+                .build();
+        feed2 = Feed.builder()
+                .title("T2")
+                .content("C2")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("www.github.com/newWisdom")
+                .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+                .build();
+        feed3 = Feed.builder()
+                .title("T3")
+                .content("C1")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("www.github.com/newWisdom")
+                .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+                .build();
+
         feedRepository.saveAll(Arrays.asList(feed1.writtenBy(user), feed2.writtenBy(user), feed3.writtenBy(user)));
 
         techRepository.saveAll(Arrays.asList(tech1, tech2, tech3));
@@ -82,7 +104,7 @@ class FeedTechServiceTest {
         Set<Feed> usingTech3 = feedTechService.findFeedUsingTech(techNames3);
 
         // then
-        assertThat(usingTech123).hasSize(0);
+        assertThat(usingTech123).isEmpty();
         assertThat(usingTech12).contains(feed1);
         assertThat(usingTech2).contains(feed1, feed2);
         assertThat(usingTech3).contains(feed2, feed3);

--- a/backend/src/test/java/com/wooteco/nolto/feed/domain/CommentTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/domain/CommentTest.java
@@ -2,7 +2,6 @@ package com.wooteco.nolto.feed.domain;
 
 import com.wooteco.nolto.auth.domain.SocialType;
 import com.wooteco.nolto.user.domain.User;
-import com.wooteco.nolto.user.domain.UserTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,8 +15,21 @@ class CommentTest {
 
     @BeforeEach
     void setUp() {
-        User user1 = new User(1L, "SOCIAL_ID", SocialType.GITHUB, "NICKNAME", "IMAGE");
-        User user2 = new User(2L, "SOCIAL_ID2", SocialType.GITHUB, "NICKNAME2", "IMAGE2");
+        User user1 = User.builder()
+                .id(1L)
+                .socialId("SOCIAL_ID")
+                .socialType(SocialType.GITHUB)
+                .nickName("NICKNAME")
+                .imageUrl("IMAGE")
+                .build();
+        User user2 =User.builder()
+                .id(2L)
+                .socialId("SOCIAL_ID2")
+                .socialType(SocialType.GITHUB)
+                .nickName("NICKNAME2")
+                .imageUrl("IMAGE")
+                .build();
+
         Feed feed = Feed.builder()
                 .title("title")
                 .content("content")

--- a/backend/src/test/java/com/wooteco/nolto/feed/domain/CommentTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/domain/CommentTest.java
@@ -11,8 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CommentTest {
 
-    public static final Comment COMMENT1 = new Comment("첫 댓글", false).writtenBy(UserTest.USER, FeedTest.FEED1);
-
     private Comment comment1;
     private Comment comment2;
 
@@ -20,14 +18,16 @@ class CommentTest {
     void setUp() {
         User user1 = new User(1L, "SOCIAL_ID", SocialType.GITHUB, "NICKNAME", "IMAGE");
         User user2 = new User(2L, "SOCIAL_ID2", SocialType.GITHUB, "NICKNAME2", "IMAGE2");
-        Feed feed = new Feed(
-                "title",
-                "content",
-                Step.PROGRESS,
-                true,
-                "https://github.com/woowacourse-teams/2021-nolto",
-                "https://github.com/woowacourse-teams/2021-nolto",
-                "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png").writtenBy(user1);
+        Feed feed = Feed.builder()
+                .title("title")
+                .content("content")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+                .deployedUrl("https://github.com/woowacourse-teams/2021-nolto")
+                .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+                .build()
+                .writtenBy(user1);
         comment1 = new Comment("첫 댓글", false).writtenBy(user1, feed);
         comment2 = new Comment("두 번째 댓글", false).writtenBy(user2, feed);
     }

--- a/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedRepositoryTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedRepositoryTest.java
@@ -39,12 +39,31 @@ class FeedRepositoryTest {
         userRepository.save(user1);
         userRepository.save(user2);
 
-        feed1 = new Feed("title1", "content1", Step.PROGRESS, true,
-                "www.github.com/woowacourse", "", DEFAULT_THUMBNAIL_IMAGE);
-        feed2 = new Feed("title2", "content2", Step.PROGRESS, false,
-                "www.github.com/woowacourse", "", DEFAULT_THUMBNAIL_IMAGE);
-        feed3 = new Feed("title3", "content3", Step.COMPLETE, false,
-                "www.github.com/woowacourse", "www.github.com/woowacourse", DEFAULT_THUMBNAIL_IMAGE);
+        feed1 = Feed.builder()
+                .title("title1")
+                .content("content1")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("www.github.com/newWisdom")
+                .thumbnailUrl(DEFAULT_THUMBNAIL_IMAGE)
+                .build();
+        feed2 = Feed.builder()
+                .title("title2")
+                .content("content2")
+                .step(Step.PROGRESS)
+                .isSos(false)
+                .storageUrl("www.github.com/newWisdom")
+                .thumbnailUrl(DEFAULT_THUMBNAIL_IMAGE)
+                .build();
+        feed3 = Feed.builder()
+                .title("title3")
+                .content("content3")
+                .step(Step.COMPLETE)
+                .isSos(false)
+                .storageUrl("www.github.com/newWisdom")
+                .deployedUrl("www.github.com/woowacourse")
+                .thumbnailUrl(DEFAULT_THUMBNAIL_IMAGE)
+                .build();
     }
 
     @DisplayName("토이 프로젝트 글을 의미하는 Feed를 저장한다.")
@@ -133,10 +152,23 @@ class FeedRepositoryTest {
     @Test
     void searchByKeywordWithKorean() {
         //given
-        feed1 = new Feed("조엘 프로젝트", "조엘의 환상적인 토이 프로젝트로 초대합니다 룰루랄라", Step.PROGRESS, true,
-                "storageUrl", "", "http://thumbnailUrl.ppnngg");
-        feed2 = new Feed("놀토 프로젝트", "놀토는 정말 세계에서 제일가는 팀입니다. 우테코 최고 아웃풋이죠", Step.PROGRESS, false,
-                "", "deployUrl", "http://thumbnailUrl.pnggg");
+        feed1 = Feed.builder()
+                .title("조엘 프로젝트")
+                .content("조엘의 환상적인 토이 프로젝트로 초대합니다 룰루랄라")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("storageUrl")
+                .thumbnailUrl(DEFAULT_THUMBNAIL_IMAGE)
+                .build();
+        feed2 = Feed.builder()
+                .title("놀토 프로젝트")
+                .content("놀토는 정말 세계에서 제일가는 팀입니다. 우테코 최고 아웃풋이죠")
+                .step(Step.PROGRESS)
+                .isSos(false)
+                .storageUrl("storageUrl")
+                .deployedUrl("deployUrl")
+                .thumbnailUrl(DEFAULT_THUMBNAIL_IMAGE)
+                .build();
 
         feedRepository.save(feed1.writtenBy(user1));
         feedRepository.save(feed2.writtenBy(user2));
@@ -163,10 +195,23 @@ class FeedRepositoryTest {
     @Test
     void searchByKeywordWithSpecialCharacter() {
         //given
-        feed1 = new Feed("조엘 프로젝트$$$$", "조엘의 ### && *** 룰루랄라", Step.PROGRESS, true,
-                "storageUrl", "", "http://thumbnailUrl.ppnngg");
-        feed2 = new Feed("놀토 프로젝트%%%%", "놀토는 ()() @@@ 우테코 최고 아웃풋", Step.PROGRESS, false,
-                "", "deployUrl", "http://thumbnailUrl.pnggg");
+        feed1 = Feed.builder()
+                .title("조엘 프로젝트프로젝트$$$$")
+                .content("조엘의 ### && *** 룰루랄라")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("storageUrl")
+                .thumbnailUrl(DEFAULT_THUMBNAIL_IMAGE)
+                .build();
+        feed2 = Feed.builder()
+                .title("놀토 프로젝트%%%%")
+                .content("놀토는 ()() @@@ 우테코 최고 아웃풋")
+                .step(Step.PROGRESS)
+                .isSos(false)
+                .storageUrl("storageUrl")
+                .deployedUrl("deployUrl")
+                .thumbnailUrl(DEFAULT_THUMBNAIL_IMAGE)
+                .build();
 
         feedRepository.save(feed1.writtenBy(user1));
         feedRepository.save(feed2.writtenBy(user2));
@@ -194,10 +239,23 @@ class FeedRepositoryTest {
     @Test
     void searchByKeywordWithAllTogether() {
         //given
-        feed1 = new Feed("JOEL 프로젝트$$$$", "조엘의 ### && *** LUlu lala", Step.PROGRESS, true,
-                "storageUrl", "", "http://thumbnailUrl.ppnngg");
-        feed2 = new Feed("놀토 project%%%%", "놀토는 ()() @@@ wootecho 최고 output", Step.PROGRESS, false,
-                "", "deployUrl", "http://thumbnailUrl.pnggg");
+        feed1 = Feed.builder()
+                .title("JOEL 프로젝트$$$$")
+                .content("조엘의 ### && *** LUlu lala")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("storageUrl")
+                .thumbnailUrl(DEFAULT_THUMBNAIL_IMAGE)
+                .build();
+        feed2 = Feed.builder()
+                .title("놀토 project%%%%")
+                .content("놀토는 ()() @@@ wootecho 최고 output")
+                .step(Step.PROGRESS)
+                .isSos(false)
+                .storageUrl("storageUrl")
+                .deployedUrl("deployUrl")
+                .thumbnailUrl(DEFAULT_THUMBNAIL_IMAGE)
+                .build();
 
         feedRepository.save(feed1.writtenBy(user1));
         feedRepository.save(feed2.writtenBy(user2));
@@ -232,6 +290,6 @@ class FeedRepositoryTest {
         Set<Feed> query1Result = feedRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(query1, query1);
 
         //then
-        assertThat(query1Result).hasSize(0);
+        assertThat(query1Result).isEmpty();
     }
 }

--- a/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedTechRepositoryTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedTechRepositoryTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.util.List;
 
+import static com.wooteco.nolto.feed.domain.FeedRepositoryTest.DEFAULT_THUMBNAIL_IMAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
@@ -43,10 +44,23 @@ class FeedTechRepositoryTest {
     @BeforeEach
     void setUp() {
         user = new User("123456L", SocialType.GOOGLE, "아마찌", "imageUrl");
-        feed1 = new Feed("조엘 프로젝트", "조엘의 환상적인 토이 프로젝트로 초대합니다 룰루랄라",
-                Step.PROGRESS, true, "storageUrl", "", "http://thumbnailUrl.ppnngg");
-        feed2 = new Feed("놀토 프로젝트", "놀토는 정말 세계에서 제일가는 팀입니다. 우테코 최고 아웃풋이죠",
-                Step.PROGRESS, false, "", "deployUrl", "http://thumbnailUrl.pnggg");
+        feed1 = Feed.builder()
+                .title("조엘 프로젝트")
+                .content("조엘의 환상적인 토이 프로젝트로 초대합니다 룰루랄라")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("storageUrl")
+                .thumbnailUrl(DEFAULT_THUMBNAIL_IMAGE)
+                .build();
+        feed2 = Feed.builder()
+                .title("놀토 프로젝트")
+                .content("놀토는 정말 세계에서 제일가는 팀입니다. 우테코 최고 아웃풋이죠")
+                .step(Step.PROGRESS)
+                .isSos(false)
+                .storageUrl("storageUrl")
+                .deployedUrl("deployUrl")
+                .thumbnailUrl(DEFAULT_THUMBNAIL_IMAGE)
+                .build();
         tech1 = new Tech("Spring");
         tech2 = new Tech("Django");
         tech3 = new Tech("MySql");

--- a/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/domain/FeedTest.java
@@ -11,27 +11,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FeedTest {
-    public static final Feed FEED1 = new Feed(
-            "title",
-            "content",
-            Step.PROGRESS,
-            true,
-            "https://github.com/woowacourse-teams/2021-nolto",
-            "https://github.com/woowacourse-teams/2021-nolto",
-            "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png").writtenBy(UserTest.USER);
 
     private Feed feed1;
 
     @BeforeEach
     void setUp() {
-        feed1 = new Feed(
-                "title",
-                "content",
-                Step.PROGRESS,
-                true,
-                "https://github.com/woowacourse-teams/2021-nolto",
-                "https://github.com/woowacourse-teams/2021-nolto",
-                "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png");
+        feed1 = Feed.builder()
+                .title("아마찌의 개쩌는 지하철 미션")
+                .content("난 너무 잘해")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+                .deployedUrl("https://github.com/woowacourse-teams/2021-nolto")
+                .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+                .build();
     }
 
     @DisplayName("피드에 작성자 추가할 수 있다.")
@@ -70,14 +63,14 @@ class FeedTest {
     @Test
     void mustHaveDeployUrlWhenCompleteStep() {
         assertThatThrownBy(() ->
-                new Feed(
-                        "프로젝트 제목",
-                        "프로젝트 소개 내용",
-                        Step.COMPLETE,
-                        false,
-                        "www.github.com/woowacourse",
-                        "",
-                        "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png"))
+                Feed.builder()
+                        .title("아마찌의 개쩌는 지하철 미션")
+                        .content("난 너무 잘해")
+                        .step(Step.COMPLETE)
+                        .isSos(true)
+                        .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+                        .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+                        .build())
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorType.MISSING_DEPLOY_URL.getMessage());
     }

--- a/backend/src/test/java/com/wooteco/nolto/notification/application/NotificationEventTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/notification/application/NotificationEventTest.java
@@ -56,14 +56,15 @@ public class NotificationEventTest {
         userRepository.save(찰리);
         userRepository.save(포모);
 
-        찰리가_쓴_피드 = new Feed(
-                "title",
-                "content",
-                Step.PROGRESS,
-                true,
-                "https://github.com/woowacourse-teams/2021-nolto",
-                "https://github.com/woowacourse-teams/2021-nolto",
-                "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png").writtenBy(찰리);
+        찰리가_쓴_피드 = Feed.builder()
+                .title("title")
+                .content("난 너무 잘해")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+                .deployedUrl("https://github.com/woowacourse-teams/2021-nolto")
+                .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+                .build().writtenBy(찰리);
         feedRepository.save(찰리가_쓴_피드);
     }
 

--- a/backend/src/test/java/com/wooteco/nolto/notification/application/NotificationServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/notification/application/NotificationServiceTest.java
@@ -119,13 +119,14 @@ class NotificationServiceTest {
     }
 
     private Feed 찰리가_쓴_피드를_생성() {
-        return new Feed(
-                "title",
-                "content",
-                Step.PROGRESS,
-                true,
-                "https://github.com/woowacourse-teams/2021-nolto",
-                "https://github.com/woowacourse-teams/2021-nolto",
-                "https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png").writtenBy(찰리);
+        return Feed.builder()
+                .title("title")
+                .content("난 너무 잘해")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+                .deployedUrl("https://github.com/woowacourse-teams/2021-nolto")
+                .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+                .build().writtenBy(찰리);
     }
 }

--- a/backend/src/test/java/com/wooteco/nolto/tech/application/TechServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/tech/application/TechServiceTest.java
@@ -11,8 +11,9 @@ import com.wooteco.nolto.tech.domain.TechRepository;
 import com.wooteco.nolto.tech.ui.dto.TechResponse;
 import com.wooteco.nolto.user.domain.User;
 import com.wooteco.nolto.user.domain.UserRepository;
-import org.junit.Before;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -51,16 +52,51 @@ class TechServiceTest {
 
     private final User user = new User("1L", SocialType.GOOGLE, "JOEL", "imageUrl");
 
-    private final Feed FEED1 = new Feed("title1", "content1",
-            Step.PROGRESS, true, "storageUrl", "", "http://thumbnailUrl.png").writtenBy(user);
-    private final Feed FEED2 = new Feed("title2", "content2",
-            Step.COMPLETE, false, "storageUrl", "deployUrl", "http://thumbnailUrl.png").writtenBy(user);
-    private final Feed FEED3 = new Feed("title3", "content3",
-            Step.PROGRESS, true, "storageUrl", "", "http://thumbnailUrl.png").writtenBy(user);
-    private final Feed FEED4 = new Feed("title4", "content4",
-            Step.PROGRESS, false, "", "deployUrl", "http://thumbnailUrl.png").writtenBy(user);
-    private final Feed FEED5 = new Feed("title5", "content5",
-            Step.COMPLETE, true, "storageUrl", "deployUrl", "http://thumbnailUrl.png").writtenBy(user);
+    private final Feed FEED1 = Feed.builder()
+            .title("title1")
+            .content("content1")
+            .step(Step.PROGRESS)
+            .isSos(true)
+            .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build().writtenBy(user);
+
+    private final Feed FEED2 = Feed.builder()
+            .title("title2")
+            .content("content2")
+            .step(Step.COMPLETE)
+            .isSos(false)
+            .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .deployedUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build().writtenBy(user);
+
+    private final Feed FEED3 = Feed.builder()
+            .title("title3")
+            .content("content3")
+            .step(Step.PROGRESS)
+            .isSos(true)
+            .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build().writtenBy(user);
+
+    private final Feed FEED4 = Feed.builder()
+            .title("title4")
+            .content("content4")
+            .step(Step.PROGRESS)
+            .isSos(false)
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build().writtenBy(user);
+
+    private final Feed FEED5 = Feed.builder()
+            .title("title5")
+            .content("content5")
+            .step(Step.COMPLETE)
+            .isSos(true)
+            .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .deployedUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build().writtenBy(user);
 
     @BeforeEach
     void setUp() {

--- a/backend/src/test/java/com/wooteco/nolto/tech/domain/TechRepositoryTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/tech/domain/TechRepositoryTest.java
@@ -46,17 +46,51 @@ class TechRepositoryTest {
 
     private final User user = new User("1L", SocialType.GOOGLE, "JOEL", "imageUrl");
 
-    private final Feed FEED1 = new Feed("title1", "content1",
-            Step.PROGRESS, true, "storageUrl", "", "http://thumbnailUrl.png").writtenBy(user);
-    private final Feed FEED2 = new Feed("title2", "content2",
-            Step.COMPLETE, false, "storageUrl", "deployUrl", "http://thumbnailUrl.png").writtenBy(user);
-    private final Feed FEED3 = new Feed("title3", "content3",
-            Step.PROGRESS, true, "storageUrl", "", "http://thumbnailUrl.png").writtenBy(user);
-    private final Feed FEED4 = new Feed("title4", "content4",
-            Step.PROGRESS, false, "", "deployUrl", "http://thumbnailUrl.png").writtenBy(user);
-    private final Feed FEED5 = new Feed("title5", "content5",
-            Step.COMPLETE, true, "storageUrl", "deployUrl", "http://thumbnailUrl.png").writtenBy(user);
+    private final Feed FEED1 = Feed.builder()
+            .title("title1")
+            .content("content1")
+            .step(Step.PROGRESS)
+            .isSos(true)
+            .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build().writtenBy(user);
 
+    private final Feed FEED2 = Feed.builder()
+            .title("title2")
+            .content("content2")
+            .step(Step.COMPLETE)
+            .isSos(false)
+            .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .deployedUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build().writtenBy(user);
+
+    private final Feed FEED3 = Feed.builder()
+            .title("title3")
+            .content("content3")
+            .step(Step.PROGRESS)
+            .isSos(true)
+            .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build().writtenBy(user);
+
+    private final Feed FEED4 = Feed.builder()
+            .title("title4")
+            .content("content4")
+            .step(Step.PROGRESS)
+            .isSos(false)
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build().writtenBy(user);
+
+    private final Feed FEED5 = Feed.builder()
+            .title("title5")
+            .content("content5")
+            .step(Step.COMPLETE)
+            .isSos(true)
+            .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .deployedUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build().writtenBy(user);
 
     @BeforeEach
     void setUp() {
@@ -114,7 +148,7 @@ class TechRepositoryTest {
         List<Tech> techs = techRepository.findAllByNameInIgnoreCase(techNames);
 
         // then
-        assertThat(techs).hasSize(0);
+        assertThat(techs).isEmpty();
     }
 
     @DisplayName("테크 이름 리스트에 대응하는 테크가 있기도 하고 없기도 하다면, 대응되는 테크만 가져온다")

--- a/backend/src/test/java/com/wooteco/nolto/user/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/user/application/MemberServiceTest.java
@@ -63,8 +63,8 @@ class MemberServiceTest {
     public static final ProfileRequest 프로필_수정_요청 = new ProfileRequest(수정할_닉네임, "안녕하세용", null);
     public static final ProfileRequest 존재하는_닉네임으로_프로필_수정_요청 = new ProfileRequest(존재하는_백신_영상_닉네임, "안녕하세용", null);
 
-    private final User 영상이 = new User(null, "1", SocialType.GITHUB, 존재하는_백신_영상_닉네임, "joel.jpg");
-    private final User 아마찌 = new User(null, "2", SocialType.GITHUB, "AMAZZI", "ama.jpg");
+    private final User 영상이 = new User("1", SocialType.GITHUB, 존재하는_백신_영상_닉네임, "joel.jpg");
+    private final User 아마찌 = new User("2", SocialType.GITHUB, "AMAZZI", "ama.jpg");
 
     private final Feed 영상이_피드 = Feed.builder()
             .title("joelFeed")

--- a/backend/src/test/java/com/wooteco/nolto/user/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/user/application/MemberServiceTest.java
@@ -66,8 +66,22 @@ class MemberServiceTest {
     private final User 영상이 = new User(null, "1", SocialType.GITHUB, 존재하는_백신_영상_닉네임, "joel.jpg");
     private final User 아마찌 = new User(null, "2", SocialType.GITHUB, "AMAZZI", "ama.jpg");
 
-    private final Feed 영상이_피드 = new Feed("joelFeed", "joelFeed", Step.PROGRESS, true, "", "", "");
-    private final Feed 아마찌_피드 = new Feed("amaFeed", "amaFeed", Step.PROGRESS, true, "", "", "");
+    private final Feed 영상이_피드 = Feed.builder()
+            .title("joelFeed")
+            .content("joelFeed")
+            .step(Step.PROGRESS)
+            .isSos(true)
+            .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build();
+    private final Feed 아마찌_피드 = Feed.builder()
+            .title("amaFeed")
+            .content("amaFeed")
+            .step(Step.PROGRESS)
+            .isSos(true)
+            .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+            .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+            .build();
 
     private final Comment 영상이_피드에_영상이_댓글 = new Comment("joelFeedJoelComment", true);
     private final Comment 아마찌_피드에_영상이_댓글 = new Comment("amaFeedJoelComment", true);

--- a/backend/src/test/java/com/wooteco/nolto/user/domain/UserRepositoryTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/user/domain/UserRepositoryTest.java
@@ -33,12 +33,12 @@ class UserRepositoryTest {
 
     @DisplayName("context가 제대로 생성되고 설정이 됐는지 확인한다.")
     @Test
-    public void context() {
+    void context() {
     }
 
     @DisplayName("User 객체 데이터베이스에 저장 된다.")
     @Test
-    public void save() {
+    void save() {
         // when
         User savedUser = userRepository.save(user1);
 
@@ -50,7 +50,7 @@ class UserRepositoryTest {
 
     @DisplayName("이미 존재하는 nickname을 가진 User를 저장하려고 하면 예외가 발생한다.")
     @Test
-    public void saveWithDuplicatedNickname() {
+    void saveWithDuplicatedNickname() {
         // given
         userRepository.save(user1);
         User duplicatedNicknameUser = new User("2222", SocialType.GOOGLE, user1.getNickName(), "image_sample.png");
@@ -62,7 +62,7 @@ class UserRepositoryTest {
 
     @DisplayName("유저의 id로 저장된 유저 정보를 조회해올 수 있다.")
     @Test
-    public void findById() {
+    void findById() {
         // given
         User savedUser = userRepository.save(user1);
 
@@ -76,7 +76,7 @@ class UserRepositoryTest {
 
     @DisplayName("존재하지 않는 유저의 id로 유저 정보를 조회하면 Optional.empty() 객체를 반환한다.")
     @Test
-    public void findByNonExistsId() {
+    void findByNonExistsId() {
         // when
         Optional<User> optionalUser = userRepository.findById(Long.MAX_VALUE);
 
@@ -86,7 +86,7 @@ class UserRepositoryTest {
 
     @DisplayName("유저의 email로 저장된 유저 정보를 조회해올 수 있다.")
     @Test
-    public void findByEmail() {
+    void findByEmail() {
         User savedUser = userRepository.save(user1);
 
         // when
@@ -100,7 +100,7 @@ class UserRepositoryTest {
 
     @DisplayName("존재하지 않는 유저의 email로 유저 정보를 조회하면 Optional.empty() 객체를 반환한다.")
     @Test
-    public void findByNonExistsEmail() {
+    void findByNonExistsEmail() {
         // when
         Optional<User> optionalUser = userRepository.findBySocialIdAndSocialType("NonExistsSocialId", null);
 
@@ -110,7 +110,7 @@ class UserRepositoryTest {
 
     @DisplayName("유저와 같은 Id를 가진 유저를 생성해서 저장하면 저장소의 데이터가 수정된다.")
     @Test
-    public void updateOtherCase() {
+    void updateOtherCase() {
         // given
         User savedUser = userRepository.save(user1);
         String newSocialId = "2222";
@@ -126,7 +126,7 @@ class UserRepositoryTest {
 
     @DisplayName("존재하는 유저의 데이터를 삭제할 수 있다.")
     @Test
-    public void delete() {
+    void delete() {
         // given
         User savedUser = userRepository.save(user1);
 
@@ -135,27 +135,31 @@ class UserRepositoryTest {
         List<User> allUsers = userRepository.findAll();
 
         // then
-        assertThat(allUsers).hasSize(0);
+        assertThat(allUsers).isEmpty();
     }
 
     @DisplayName("저장된 유저의 ID와 같은 ID를 가진 객체로 저장을 시도해도 삭제가 가능하다.")
     @Test
-    public void deleteWithSameIdAndDiffInfoObject() {
+    void deleteWithSameIdAndDiffInfoObject() {
         // given
         userRepository.save(user1);
-        User otherUser = new User(user1.getId(), "1234", SocialType.GOOGLE, "Gomding");
-
+        User otherUser = User.builder()
+                .id(user1.getId())
+                .socialId("1234")
+                .socialType(SocialType.GOOGLE)
+                .nickName("Gomding")
+                .build();
         // when
         userRepository.delete(otherUser);
         List<User> allUsers = userRepository.findAll();
 
         // then
-        assertThat(allUsers).hasSize(0);
+        assertThat(allUsers).isEmpty();
     }
 
     @DisplayName("존재하지 않는 유저를 삭제하려고 하면 정상 실행된다.")
     @Test
-    public void deleteWithNonExistsId() {
+    void deleteWithNonExistsId() {
         // when
         userRepository.delete(user1);
 

--- a/backend/src/test/java/com/wooteco/nolto/user/domain/UserTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/user/domain/UserTest.java
@@ -4,6 +4,7 @@ import com.wooteco.nolto.auth.domain.SocialType;
 import com.wooteco.nolto.feed.domain.Feed;
 import com.wooteco.nolto.feed.domain.Like;
 import com.wooteco.nolto.feed.domain.Step;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -17,11 +18,24 @@ public class UserTest {
 
     public static User USER = new User(SOCIAL_ID, GITHUB_SOCIAL_TYPE, NICKNAME, IMAGE);
 
+    private Feed feed;
+
+    @BeforeEach
+    void setUp() {
+        feed = Feed.builder()
+                .title("title1")
+                .content("content1")
+                .step(Step.PROGRESS)
+                .isSos(true)
+                .storageUrl("https://github.com/woowacourse-teams/2021-nolto")
+                .thumbnailUrl("https://dksykemwl00pf.cloudfront.net/nolto-default-thumbnail.png")
+                .build();
+    }
+
     @DisplayName("멤버가 해당 피드에 좋아요를 눌렀는지 검증한다.")
     @Test
     void isLiked() {
         User user = new User(SOCIAL_ID, SocialType.GITHUB, NICKNAME, IMAGE);
-        Feed feed = new Feed("title", "content", Step.PROGRESS, true, "", "", "");
         feed.writtenBy(user);
 
         user.getLikes().add(new Like(user, feed));
@@ -34,7 +48,6 @@ public class UserTest {
     void isNotLiked() {
         User user1 = new User(SOCIAL_ID, SocialType.GITHUB, NICKNAME, IMAGE);
         User user2 = new User("98765L", SocialType.GOOGLE, "amazzi", IMAGE);
-        Feed feed = new Feed("title", "content", Step.PROGRESS, true, "", "", "");
         feed.writtenBy(user1);
 
         user1.getLikes().add(new Like(user1, feed));
@@ -45,8 +58,6 @@ public class UserTest {
     @DisplayName("게스트가 해당 피드에 좋아요를 눌렀는지 검증하면 무조건 false이다.")
     @Test
     void isLikedWithGuest() {
-        Feed feed = new Feed("title", "content", Step.PROGRESS, true, "", "", "");
-
         User guestUser = User.GUEST_USER;
 
         assertThat(guestUser.isLiked(feed)).isFalse();


### PR DESCRIPTION
## 작업 내용
- `@AllArgsConstructor` 대신 `@RequiredArgsConstructor`로 변경 (통일성 및 [이런 이슈도 있다고함](https://blog.hodory.dev/2019/05/28/required-a-bean-of-type-that-could-not-be-found/))
- service, controller 등 스프링 mvc 관련한 빈들은 `@RequiredArgsConstructor` 유지 
- 도메인 `@AllArgsConstructor` 제거 및 빌더 패턴 적용 (`@Builder`)
- 롬복 순서 정리 (`@Entity`, `@RestController` 등 해딩 클래스를 나타내는 어노테이션을 가장 상단에 두도록 통일성 맞춤)
- ControllerTest를 상속받는 클래스들에서 중복되는 변수들을 추상 클래스로 끌어올림
- Entity 클래스의 `@NoArgsConstructor` 접근 권한 최소화 
  - JPA에서는 프록시를 생성을 위해서 기본 생성자를 반드시 하나 만들어야하는데, 굳이 외부에서 생성을 열어둘 필요없게하기 위해 접근 권한을 protected로 제한.
- 생성자에서 `@Builder`를 사용해 컬렉션 같은 값들이 null 이 되는 것을 방지
   - [참고 - Builder 사용 시 NullPointerException 뜨는 경우 참고사항 (NPE)](https://www.inflearn.com/questions/151658)
   - 번외로 기본 값을 설정하는 방법 중 `@Builder.Default`를 변수에 사용하는 방법도 있음
- 전반적인 코드 정리 

 

Closed #373 


## 주의사항
- 일단 파일을 많이 건들여서 좀 무서워요
- 반박, 기각 괜찮습니다 !!
- 현재 쓰고 있는 생성자가 너무 무수히 많았기에... 일단 볼 때 매개변수가 너무 많은 feed 같은 경우는 빌더로 다 바꾸고, 
매개변수가 많지 않고(한 4개까지 허용) 가독성이 크게 떨어지지 않는 생성자는 냅두고 생성자로 객체를 만들도록 납두었습니다. (빌더패턴을 쓰면 오히려 길어질 것 같아서) 


## 참고한 자료들
* [Lombok 사용상 주의점(Pitfall) - 권남](https://kwonnam.pe.kr/wiki/java/lombok/pitfall)
* [Builder 기반으로 객체를 안전하게 생성하는 방법](https://cheese10yun.github.io/spring-builder-pattern/)
* [실무에서 Lombok 사용법](https://github.com/cheese10yun/blog-sample/tree/master/lombok)
* [빌더 패턴의 권장 이유](https://devfunny.tistory.com/337)
* [포모 추천 [Java] 디자인 패턴 - Builder 패턴](https://velog.io/@lsj8367/%EB%B9%8C%EB%8D%94%ED%8C%A8%ED%84%B4Builder-Pattern)