### PR TITLE
[FE] fix: 검색 결과 페이지 카드 렌더링 수정

### DIFF
--- a/frontend/src/pages/SearchResult/SearchResult.styles.ts
+++ b/frontend/src/pages/SearchResult/SearchResult.styles.ts
@@ -1,15 +1,13 @@
 import styled from 'styled-components';
 
 import HighLightedText from 'components/@common/HighlightedText/HighlightedText';
-import TechInputComponent from 'contexts/techTag/input/TechInput';
 
 const TopContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   width: 100%;
-  padding-top: 4rem;
-  padding-bottom: 2rem;
+  margin-bottom: 2rem;
   z-index: 10;
 `;
 

--- a/frontend/src/pages/SearchResult/SearchResultContent/SearchResultContent.styles.ts
+++ b/frontend/src/pages/SearchResult/SearchResultContent/SearchResultContent.styles.ts
@@ -1,59 +1,18 @@
 import styled from 'styled-components';
 
-import Avatar from 'components/@common/Avatar/Avatar';
-import { PALETTE } from 'constants/palette';
-import DownPolygon from 'assets/downPolygon.svg';
-import { hoverLayer } from 'commonStyles';
-
 const Root = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
 `;
 
-const ScrollableContainer = styled.ul`
+const RecentFeedsContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   grid-gap: 1rem;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-
-  /* Hide scrollbar for IE, Edge and Firefox */
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-
-  & li {
-    margin-bottom: 0.25rem;
-  }
-`;
-
-const VerticalAvatar = styled(Avatar)`
-  margin-bottom: 12px;
-`;
-
-const MoreButton = styled.button`
-  bottom: 0.25rem;
-  width: calc(100% - 0.5rem);
-  height: 1.25rem;
-  margin: 0 0.5rem;
-  border: none;
-  border-radius: 0.25rem;
-  background-color: ${PALETTE.WHITE_400};
-  filter: drop-shadow(0 0 0.25rem rgba(0, 0, 0, 0.25));
-
-  ${hoverLayer({})};
-`;
-
-export const MoreFeedsArrow = styled(DownPolygon)`
-  fill: ${PALETTE.PRIMARY_400};
 `;
 
 export default {
   Root,
-  ScrollableContainer,
-  VerticalAvatar,
-  MoreButton,
-  MoreFeedsArrow,
+  RecentFeedsContainer,
 };

--- a/frontend/src/pages/SearchResult/SearchResultContent/SearchResultContent.tsx
+++ b/frontend/src/pages/SearchResult/SearchResultContent/SearchResultContent.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
-import Skeleton from 'components/Skeleton/Skeleton';
 import RegularFeedCard from 'components/RegularFeedCard/RegularFeedCard';
-import ROUTE from 'constants/routes';
 import useSnackbar from 'contexts/snackbar/useSnackbar';
 import useSearch from 'hooks/queries/useSearch';
 import { FilterType } from 'types';
-import Styled, { MoreFeedsArrow } from './SearchResultContent.styles';
+import Styled from './SearchResultContent.styles';
 
 interface Props {
   query: string;
@@ -18,35 +15,19 @@ interface Props {
 const SearchResultContent = (searchParams: Props) => {
   const snackbar = useSnackbar();
 
-  const { data: feeds, isLoading } = useSearch({
+  const { data: feeds } = useSearch({
     searchParams,
     errorHandler: (error) => snackbar.addSnackbar('error', error.message),
     suspense: false,
   });
 
-  const isOverflown = feeds?.length >= 3;
-
-  const DEFAULT_FEED_LENGTH = 4;
-
   return (
     <Styled.Root>
-      <Styled.ScrollableContainer>
-        {isLoading
-          ? Array.from({ length: DEFAULT_FEED_LENGTH }, () => <Skeleton />)
-          : feeds?.map((feed) => (
-              <li key={feed.id}>
-                <Link to={`${ROUTE.FEEDS}/${feed.id}`}>
-                  <RegularFeedCard feed={feed} />
-                </Link>
-              </li>
-            ))}
-      </Styled.ScrollableContainer>
-
-      {isOverflown && (
-        <Styled.MoreButton>
-          <MoreFeedsArrow width="14px" />
-        </Styled.MoreButton>
-      )}
+      <Styled.RecentFeedsContainer>
+        {feeds?.map((feed) => (
+          <RegularFeedCard key={feed.id} feed={feed} />
+        ))}
+      </Styled.RecentFeedsContainer>
     </Styled.Root>
   );
 };


### PR DESCRIPTION
## 작업 내용
fix: 검색 결과 페이지 카드 렌더링 수정

Closes #524

## 스크린샷
기술스택으로 검색 시
![image](https://user-images.githubusercontent.com/44080404/132714313-313ca50f-263e-46b4-91d8-a7ecfe86c77c.png)

제목/내용으로 검색 시
![image](https://user-images.githubusercontent.com/44080404/132714356-26fd002d-067d-4f85-bc98-6dcae5c0a39b.png)

## 주의사항
금방 고치긴 했는데 최신 피드의 인피니트 스크롤 반영되면 얘도 같이 적용해서 머지해야 할 듯!!
