### PR TITLE
fix(): ffmpeg 경로를 ubuntu에 맞추어 설정

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,9 +41,9 @@ application:
   cors:
     allow-origin: "*"
 ffmpeg:
-  path: /usr/local/bin/ffmpeg
+  path: /usr/bin/ffmpeg
 ffprobe:
-  path: /usr/local/bin/ffprobe
+  path: /usr/bin/ffprobe
 ---
 spring:
   config:


### PR DESCRIPTION
## 작업 내용
- ec2 서버에 맞는 ffmpeg 관련 경로 yml 설정 추가 


## 주의사항
- 알아서 로컬 ffmpeg 패스 맞추세요~
- usr/bin