### PR TITLE
fix(): api 문서 resource 경로 허용

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/WebConfig.java
+++ b/backend/src/main/java/com/wooteco/nolto/WebConfig.java
@@ -3,6 +3,7 @@ package com.wooteco.nolto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -16,5 +17,10 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedMethods("*")
                 .allowedOriginPatterns(allowOrigin);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/docs/**").addResourceLocations("classpath:/static/docs/");
     }
 }


### PR DESCRIPTION
## 작업 내용

- resource 차단으로 죽어버린 api 문서 살리기



## 주의사항
