### PR TITLE
[FE] fix: 카카오 중복 init 오류 수정

### DIFF
--- a/frontend/custom.d.ts
+++ b/frontend/custom.d.ts
@@ -1,3 +1,5 @@
+export {};
+
 interface SVGProps {
   fill?: string;
   width?: string;
@@ -18,7 +20,9 @@ declare module '*.webp';
 
 declare module '*.gif';
 
-interface Window {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Kakao: any;
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Kakao: any;
+  }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
@@ -25,6 +25,12 @@ const queryClient = new QueryClient({
 });
 
 const App = () => {
+  useEffect(() => {
+    if (process.env.KAKAO_API_KEY && !window.Kakao.isInitialized()) {
+      window.Kakao.init(process.env.KAKAO_API_KEY);
+    }
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <ErrorBoundary fallback={<ErrorFallback message={ERROR_MSG.UNKNOWN_ERROR} />}>

--- a/frontend/src/pages/FeedDetail/FeedDetailContent/FeedDetailContent.test.tsx
+++ b/frontend/src/pages/FeedDetail/FeedDetailContent/FeedDetailContent.test.tsx
@@ -10,6 +10,9 @@ describe('FeedDetailContent 테스트', () => {
   });
 
   it('피드 상세 페이지의 세부 항목들을 보여준다.', async () => {
+    window.Kakao = {};
+    window.Kakao.isInitialized = jest.fn();
+
     const { getByText, getByRole } = customRender(<FeedDetailContent feedId={1} />);
 
     await waitFor(() => {

--- a/frontend/src/pages/FeedDetail/FeedDetailContent/FeedDetailContent.tsx
+++ b/frontend/src/pages/FeedDetail/FeedDetailContent/FeedDetailContent.tsx
@@ -111,8 +111,7 @@ const FeedDetailContent = ({ feedId }: Props) => {
   };
 
   useEffect(() => {
-    if (process.env.KAKAO_API_KEY) {
-      window.Kakao.init(process.env.KAKAO_API_KEY);
+    if (window.Kakao.isInitialized()) {
       createKakaoShare();
       setKakaoLoaded(true);
     }


### PR DESCRIPTION
## 작업 내용
피드 상세 페이지에 들어갈 때마다 `Kakao.init`을 계속 해주고 있어서, 이미 `init`되어 있는 경우 중복 `init` 에러가 남
`init`되지 않은 경우에만 `init`하도록 수정

