### PR TITLE
[FE] 검색 결과 페이지 검색 아이콘 표시, 피드 전체보기 시 마크다운 제거

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     "react-markdown": "^7.0.1",
     "react-query": "^3.18.1",
     "react-router-dom": "^5.2.0",
+    "remove-markdown": "^0.3.0",
     "styled-components": "^5.3.0"
   },
   "devDependencies": {
@@ -60,6 +61,7 @@
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.9",
     "@types/react-router-dom": "^5.1.8",
+    "@types/remove-markdown": "^0.3.1",
     "@types/styled-components": "^5.1.14",
     "@typescript-eslint/eslint-plugin": "^4.28.2",
     "@typescript-eslint/parser": "^4.28.2",

--- a/frontend/src/components/FeedUploadForm/FeedUploadForm.tsx
+++ b/frontend/src/components/FeedUploadForm/FeedUploadForm.tsx
@@ -124,9 +124,9 @@ const FeedUploadForm = ({ onFeedSubmit, initialFormValue }: Props) => {
               id="content"
               {...register('content', { required: UPLOAD_VALIDATION_MSG.CONTENT_REQUIRED })}
             />
-            <ErrorMessage targetError={errors.content} />
             <Markdown children={watchContent} />
           </Styled.MarkdownContainer>
+          <ErrorMessage targetError={errors.content} />
         </Styled.VerticalWrapper>
 
         <div>

--- a/frontend/src/components/LargeFeedCard/LargeFeedCard.tsx
+++ b/frontend/src/components/LargeFeedCard/LargeFeedCard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 
 import Avatar from 'components/@common/Avatar/Avatar';
 import FeedThumbnail from 'components/FeedThumbnail/FeedThumbnail';
+import { removeMarkdown } from 'utils/common';
 import { Feed } from 'types';
 import Styled from './LargeFeedCard.styles';
 
@@ -20,7 +21,7 @@ const LargeFeedCard = ({ feed, className }: Props) => {
           <FeedThumbnail thumbnailUrl={feed.thumbnailUrl} />
           <Styled.ContentWrapper className="card-content">
             <Styled.Title>{feed.title}</Styled.Title>
-            <Styled.Content>{feed.content}</Styled.Content>
+            <Styled.Content>{removeMarkdown(feed.content)}</Styled.Content>
           </Styled.ContentWrapper>
         </Styled.FeedContainer>
       </Link>

--- a/frontend/src/components/RegularFeedCard/RegularFeedCard.tsx
+++ b/frontend/src/components/RegularFeedCard/RegularFeedCard.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import Avatar from 'components/@common/Avatar/Avatar';
 import SOSFlag from 'components/@common/SOSFlag/SOSFlag';
 import FeedThumbnail from 'components/FeedThumbnail/FeedThumbnail';
+import { removeMarkdown } from 'utils/common';
 import { Feed } from 'types';
 import Styled from './RegularFeedCard.styles';
 
@@ -22,7 +23,7 @@ const RegularFeedCard = ({ feed }: Props) => {
         </Styled.RegularCardImgWrapper>
         <Styled.Content>
           <h3>{feed.title}</h3>
-          <p>{feed.content}</p>
+          <p>{removeMarkdown(feed.content)}</p>
         </Styled.Content>
       </Link>
     </Styled.Root>

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -11,10 +11,11 @@ export const ALERT_MSG = {
   SUCCESS_MODIFY_FEED: '토이 프로젝트를 수정했습니다.',
   SUCCESS_EDIT_PROFILE: '프로필 정보를 수정했습니다.',
   FAIL_EDIT_PROFILE: '프로필 정보 수정에 실패했습니다.',
+  SESSION_EXPIRED: '로그인 정보가 만료되었습니다.\n다시 로그인 해주세요',
 };
 
 export const CONFIRM_MSG = {
-  LEAVE_UPLOAD_PAGE: '정말로 페이지를 떠나시겠습니까? 작성 중인 정보는 사라집니다.',
+  LEAVE_UPLOAD_PAGE: '정말로 페이지를 떠나시겠습니까?\n작성 중인 정보는 사라집니다.',
 };
 
 export const ERROR_MSG = {

--- a/frontend/src/contexts/dialog/DialogProvider.styles.ts
+++ b/frontend/src/contexts/dialog/DialogProvider.styles.ts
@@ -45,6 +45,7 @@ const DialogInner = styled.div`
 
   & .message {
     padding: 0 1.5rem;
+    white-space: pre-line;
   }
 `;
 

--- a/frontend/src/hooks/queries/useMember.tsx
+++ b/frontend/src/hooks/queries/useMember.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from 'react-query';
 
 import api from 'constants/api';
 import QUERY_KEYS from 'constants/queryKeys';
+import { ALERT_MSG } from 'constants/message';
 import HttpError from 'utils/HttpError';
 import useModal from 'contexts/modal/useModal';
 import useDialog from 'contexts/dialog/useDialog';
@@ -45,7 +46,7 @@ const useMember = () => {
       useErrorBoundary: false,
       onError: (error) => {
         if (error instanceof HttpError) {
-          dialog.alert('로그인 정보가 만료되었습니다. 다시 로그인 해주세요.');
+          dialog.alert(ALERT_MSG.SESSION_EXPIRED);
           logout();
           modal.openModal(<LoginModal />);
         }

--- a/frontend/src/pages/Mypage/History/History.tsx
+++ b/frontend/src/pages/Mypage/History/History.tsx
@@ -5,7 +5,7 @@ import useUserHistory from 'hooks/queries/userHistory/useUserHistory';
 import useSnackbar from 'contexts/snackbar/useSnackbar';
 import ROUTE from 'constants/routes';
 import ReturnArrow from 'assets/arrowReturnRight.svg';
-import { genNewId } from 'utils/common';
+import { genNewId, removeMarkdown } from 'utils/common';
 import { Feed, FeedWithComment, UserHistoryType } from 'types';
 import Styled from './History.styles';
 
@@ -39,7 +39,7 @@ const History = () => {
       <Styled.FeedThumbnail thumbnailUrl={feed.thumbnailUrl} />
       <Styled.FeedContentWrapper>
         <Styled.FeedTitle>{feed.title}</Styled.FeedTitle>
-        <Styled.FeedContent>{feed.content}</Styled.FeedContent>
+        <Styled.FeedContent>{removeMarkdown(feed.content)}</Styled.FeedContent>
       </Styled.FeedContentWrapper>
     </Styled.FeedWrapper>
   );

--- a/frontend/src/pages/SearchResult/SearchResultHeader/SearchResultHeader.styles.ts
+++ b/frontend/src/pages/SearchResult/SearchResultHeader/SearchResultHeader.styles.ts
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 
-import TechInputComponent from 'contexts/techTag/input/TechInput';
 import { PALETTE } from 'constants/palette';
 import { Z_INDEX } from 'constants/styles';
 

--- a/frontend/src/pages/SearchResult/SearchResultHeader/SearchResultHeader.tsx
+++ b/frontend/src/pages/SearchResult/SearchResultHeader/SearchResultHeader.tsx
@@ -3,13 +3,14 @@ import { useHistory } from 'react-router-dom';
 
 import TechTagProvider from 'contexts/techTag/TechTagProvider';
 import useSnackbar from 'contexts/snackbar/useSnackbar';
+import TechChips from 'contexts/techTag/chip/TechChips';
+import TechInput from 'contexts/techTag/input/TechInput';
+import { PALETTE } from 'constants/palette';
 import ROUTE from 'constants/routes';
 import useTechsLoad from 'hooks/queries/useTechsLoad';
 import SearchIcon from 'assets/search.svg';
 import { Tech } from 'types';
 import Styled from './SearchResultHeader.styles';
-import TechChips from 'contexts/techTag/chip/TechChips';
-import TechInput from 'contexts/techTag/input/TechInput';
 
 interface Props {
   searchParams: string;
@@ -77,7 +78,7 @@ const SearchResultHeader = ({ searchParams, query, setQuery, techs, setTechs }: 
             onChange={(event) => setQueryValue(event.target.value)}
           />
           <Styled.Button>
-            <SearchIcon width="32px" />
+            <SearchIcon width="32px" fill={PALETTE.PRIMARY_400} />
           </Styled.Button>
         </Styled.SearchbarContainer>
       )}

--- a/frontend/src/utils/common.ts
+++ b/frontend/src/utils/common.ts
@@ -1,3 +1,6 @@
+import removeMd from 'remove-markdown';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const except = (object: any, keys: string[]) => {
   if (keys.some((key) => object?.[key] === undefined)) {
     console.error('except(object,keys) : 해당 key 값이 object에 존재하지 않습니다');
@@ -35,4 +38,13 @@ export const genNewId = function* () {
   while (true) {
     yield id++;
   }
+};
+
+export const removeMarkdown = (text: string) => {
+  return removeMd(text, {
+    stripListLeaders: true,
+    listUnicodeChar: '',
+    gfm: true,
+    useImgAltText: true,
+  });
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3124,6 +3124,11 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/remove-markdown@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@types/remove-markdown/-/remove-markdown-0.3.1.tgz#82bc3664c313f50f7c77f1bb59935f567689dc63"
+  integrity sha512-JpJNEJEsmmltyL2LdE8KRjJ0L2ad5vgLibqNj85clohT9AyTrfN6jvHxStPshDkmtcL/ShFu0p2tbY7DBS1mqQ==
+
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
@@ -11477,6 +11482,11 @@ remove-accents@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
   integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
+remove-markdown@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/remove-markdown/-/remove-markdown-0.3.0.tgz#5e4b667493a93579728f3d52ecc1db9ca505dc98"
+  integrity sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg=
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
## 작업 내용
- 검색 결과 페이지 검색 아이콘 표시
- 피드 전체보기 시 마크다운 제거
- 피드 업로드 시 마크다운 영역 에러 메시지 배치 수정
- dialog 팝업창 텍스트 개행

## 스크린샷
이런 이미지가
![image](https://user-images.githubusercontent.com/44080404/133396691-644d19ee-999a-44be-bc11-8fac6fbd7573.png)

이렇게
![image](https://user-images.githubusercontent.com/44080404/133396712-d9ed645c-d4cb-475c-b62e-66bf5c7eb44d.png)

검색 아이콘도 다시 살리기
![image](https://user-images.githubusercontent.com/44080404/133396743-f8b962ad-69f9-47ec-bfa9-68e4150f019e.png)

## 추가
이랬던거
![image](https://user-images.githubusercontent.com/44080404/133530600-e50e4045-2b9d-429c-a29b-5f6ad8993b59.png)

이렇게
![image](https://user-images.githubusercontent.com/44080404/133530614-f7cf04bf-0bc6-4a29-b75c-22263fdf0940.png)

이랬던거
![image](https://user-images.githubusercontent.com/44080404/133530629-cf9f8c22-481f-49a3-804c-262488bf939d.png)

이렇게 두줄로
![image](https://user-images.githubusercontent.com/44080404/133530642-abd0cff1-4cc2-4445-a936-6fb9296a810b.png)

