### PR TITLE
refactor: image 변환시 투명 배경을 유지할 수 있도록 ImageType 변경

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/image/application/ImageResizeService.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/application/ImageResizeService.java
@@ -54,7 +54,7 @@ public class ImageResizeService {
         int resizedHeight = (int) (resizeRatio * originalHeight);
 
         Image resizedImage = originalImage.getScaledInstance(resizedWidth, resizedHeight, Image.SCALE_SMOOTH);
-        BufferedImage resizedBufferedImage = new BufferedImage(resizedWidth, resizedHeight, BufferedImage.TYPE_INT_RGB);
+        BufferedImage resizedBufferedImage = new BufferedImage(resizedWidth, resizedHeight, BufferedImage.TYPE_INT_ARGB);
         resizedBufferedImage.getGraphics().drawImage(resizedImage, 0, 0, null);
         return resizedBufferedImage;
     }


### PR DESCRIPTION
## 작업 내용

* 이미지 변환 작업에서 배경이 투명인 이미지를 올리면 검은색으로 바뀌던 현상 확인
* ImageType 투명도를 지원하도록 변경
* TYPE_INT_RGB -> TYPE_INT_ARGB

Closes #565 

## 스크린샷
![mickey](https://user-images.githubusercontent.com/57378410/133397308-dddf3512-18b2-4904-82b6-c6e53b7ce1ec.png)


## 주의사항
미키의 당당한 자세 주의