### PR TITLE
[BE] refactor: FFmpeg Path 설정 애플리케이션이 관리하도록 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
     // ffmpeg
     implementation 'net.bramp.ffmpeg:ffmpeg:0.6.2'
+    implementation 'org.bytedeco:ffmpeg:4.4-1.5.6'
+    implementation 'org.bytedeco:javacpp:1.5.6'
+    implementation 'org.bytedeco:javacv-platform:1.5.6'
 
     // Testcontainers
     implementation("com.amazonaws:aws-java-sdk-s3")

--- a/backend/src/main/java/com/wooteco/nolto/exception/ErrorType.java
+++ b/backend/src/main/java/com/wooteco/nolto/exception/ErrorType.java
@@ -25,7 +25,7 @@ public enum ErrorType {
     NOT_SUPPORTED_STEP("feed-006", "지원하지 않는 피드의 Step입니다."),
     MULTIPART_CONVERT_FAIL("feed-007", "MultipartFile 변환에 실패하였습니다."),
     IMAGE_RESIZING_FAIL("feed-008", "이미지 리사이징에 실패하였습니다."),
-    GIF_MP4_CONVERT_FAIL("feed-009", "git파일을 mp4파일로 변환에 실패하였습니다."),
+    GIF_MP4_CONVERT_FAIL("feed-009", "gif파일을 mp4파일로 변환에 실패하였습니다."),
 
     NOT_SUPPORTED_IMAGE("image-001", "지원하지 않는 이미지 입니다."),
 

--- a/backend/src/main/java/com/wooteco/nolto/image/application/ImageConvertService.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/application/ImageConvertService.java
@@ -1,5 +1,7 @@
 package com.wooteco.nolto.image.application;
 
+import com.wooteco.nolto.exception.BadRequestException;
+import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.image.FileExtension;
 import com.wooteco.nolto.image.infrastructure.FFmpegConverter;
 import lombok.RequiredArgsConstructor;
@@ -16,17 +18,21 @@ public class ImageConvertService {
     private final FFmpegConverter ffmpegConverter;
 
     public File convertGifToMp4(File gifFile) {
-
         String gifFilePath = gifFile.getPath();
-        if (FileExtension.isNotGifFile(gifFilePath)) {
-            throw new IllegalArgumentException("gif 확장자가 아닌 파일입니다.");
-        }
+        validateGifFile(gifFilePath);
+
         int indexOfExtensionDot = gifFilePath.lastIndexOf(FileExtension.FILENAME_EXTENSION_DOT);
         String filePathWithoutExtension = gifFilePath.substring(0, indexOfExtensionDot);
         String mp4FilePath = filePathWithoutExtension + FileExtension.MP4;
-
         ffmpegConverter.convertGifToMp4(gifFilePath, mp4FilePath);
 
         return new File(mp4FilePath);
+    }
+
+    private void validateGifFile(String gifFilePath) {
+        if (FileExtension.isNotGifFile(gifFilePath)) {
+            log.error("gif 확장자가 아닌 파일입니다.");
+            throw new BadRequestException(ErrorType.GIF_MP4_CONVERT_FAIL);
+        }
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/image/application/ImageResizeService.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/application/ImageResizeService.java
@@ -10,21 +10,17 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
 
 @Service
 public class ImageResizeService {
 
     public File resize(File file, String fileName) {
         try {
-            BufferedImage image = ImageIO.read(file);
-            BufferedImage resizedImage = resizeImage(image, fileName);
+            BufferedImage originalImage = ImageIO.read(file);
+            BufferedImage resizedImage = resizeImage(originalImage, fileName);
 
-            if (resizedImage.equals(image)) {
-                return file;
-            }
-            File resizedFile = new File(fileName);
-            ImageIO.write(resizedImage, FilenameUtils.getExtension(fileName), resizedFile);
-            return resizedFile;
+            return getFile(file, fileName, originalImage, resizedImage);
         } catch (Exception e) {
             throw new InternalServerErrorException(ErrorType.IMAGE_RESIZING_FAIL);
         }
@@ -51,8 +47,16 @@ public class ImageResizeService {
     private BufferedImage getBufferedImage(String fileName, int resizedWidth, int resizedHeight) {
         if ("png".equals(FilenameUtils.getExtension(fileName))) {
             return new BufferedImage(resizedWidth, resizedHeight, BufferedImage.TYPE_INT_ARGB);
-        } else {
-            return new BufferedImage(resizedWidth, resizedHeight, BufferedImage.TYPE_INT_RGB);
         }
+        return new BufferedImage(resizedWidth, resizedHeight, BufferedImage.TYPE_INT_RGB);
+    }
+
+    private File getFile(File file, String fileName, BufferedImage originalImage, BufferedImage resizedImage) throws IOException {
+        if (resizedImage.equals(originalImage)) {
+            return file;
+        }
+        File resizedFile = new File(fileName);
+        ImageIO.write(resizedImage, FilenameUtils.getExtension(fileName), resizedFile);
+        return resizedFile;
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/image/application/ImageResizeService.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/application/ImageResizeService.java
@@ -2,6 +2,7 @@ package com.wooteco.nolto.image.application;
 
 import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.exception.InternalServerErrorException;
+import com.wooteco.nolto.image.infrastructure.ImageSize;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.stereotype.Service;
 
@@ -13,13 +14,10 @@ import java.io.File;
 @Service
 public class ImageResizeService {
 
-    private static final double MAX_PIXEL = 400.0;
-    private static final double RESIZE_NOT_NEEDED = 1.0;
-
     public File resize(File file, String fileName) {
         try {
             BufferedImage image = ImageIO.read(file);
-            BufferedImage resizedImage = resizeImage(image, image.getWidth(), image.getHeight(), fileName);
+            BufferedImage resizedImage = resizeImage(image, fileName);
 
             if (resizedImage.equals(image)) {
                 return file;
@@ -32,36 +30,29 @@ public class ImageResizeService {
         }
     }
 
-    private BufferedImage resizeImage(BufferedImage originalImage, int originalWidth, int originalHeight, String fileName) {
-        double resizeRatio = calculateResizeRatio(originalWidth, originalHeight);
-        if (resizeRatio == RESIZE_NOT_NEEDED) {
+    private BufferedImage resizeImage(BufferedImage originalImage, String fileName) {
+        ImageSize imageSize = ImageSize.of(originalImage).resize();
+        if (imageSize.doNotNeedResize(originalImage)) {
             return originalImage;
         }
-        return resizeImageByRatio(originalImage, originalWidth, originalHeight, resizeRatio, fileName);
+        return resizeImageByRatio(originalImage, imageSize, fileName);
     }
 
-    private double calculateResizeRatio(int width, int height) {
-        if (width <= MAX_PIXEL && height <= MAX_PIXEL) {
-            return RESIZE_NOT_NEEDED;
-        }
-        if (width < height) {
-            return (MAX_PIXEL / height);
-        }
-        return (MAX_PIXEL / width);
-    }
-
-    private BufferedImage resizeImageByRatio(BufferedImage originalImage, int originalWidth, int originalHeight, double resizeRatio, String fileName) {
-        int resizedWidth = (int) (resizeRatio * originalWidth);
-        int resizedHeight = (int) (resizeRatio * originalHeight);
+    private BufferedImage resizeImageByRatio(BufferedImage originalImage, ImageSize resizedImageSize, String fileName) {
+        int resizedWidth = resizedImageSize.getWidth();
+        int resizedHeight = resizedImageSize.getHeight();
 
         Image resizedImage = originalImage.getScaledInstance(resizedWidth, resizedHeight, Image.SCALE_SMOOTH);
-        BufferedImage resizedBufferedImage;
-        if ("png".equals(FilenameUtils.getExtension(fileName))) {
-            resizedBufferedImage = new BufferedImage(resizedWidth, resizedHeight, BufferedImage.TYPE_INT_ARGB);
-        } else {
-            resizedBufferedImage = new BufferedImage(resizedWidth, resizedHeight, BufferedImage.TYPE_INT_RGB);
-        }
+        BufferedImage resizedBufferedImage = getBufferedImage(fileName, resizedWidth, resizedHeight);
         resizedBufferedImage.getGraphics().drawImage(resizedImage, 0, 0, null);
         return resizedBufferedImage;
+    }
+
+    private BufferedImage getBufferedImage(String fileName, int resizedWidth, int resizedHeight) {
+        if ("png".equals(FilenameUtils.getExtension(fileName))) {
+            return new BufferedImage(resizedWidth, resizedHeight, BufferedImage.TYPE_INT_ARGB);
+        } else {
+            return new BufferedImage(resizedWidth, resizedHeight, BufferedImage.TYPE_INT_RGB);
+        }
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/image/config/FFmpegConfig.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/config/FFmpegConfig.java
@@ -1,8 +1,7 @@
 package com.wooteco.nolto.image.config;
 
 import net.bramp.ffmpeg.FFmpeg;
-import net.bramp.ffmpeg.FFprobe;
-import org.springframework.beans.factory.annotation.Value;
+import org.bytedeco.javacpp.Loader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,19 +10,9 @@ import java.io.IOException;
 @Configuration
 public class FFmpegConfig {
 
-    @Value("${ffmpeg.path}")
-    private String ffmpegPath;
-
-    @Value("${ffprobe.path}")
-    private String ffprobePath;
-
     @Bean
     public FFmpeg ffmpeg() throws IOException {
+        String ffmpegPath = Loader.load(org.bytedeco.ffmpeg.ffmpeg.class);
         return new FFmpeg(ffmpegPath);
-    }
-
-    @Bean
-    public FFprobe ffprobe() throws IOException {
-        return new FFprobe(ffprobePath);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/image/infrastructure/FFmpegConverter.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/infrastructure/FFmpegConverter.java
@@ -27,6 +27,7 @@ public class FFmpegConverter {
     public void convertGifToMp4(String gifFilePath, String mp4FilePath) {
         log.info("convert gif to mp4 {} -> {}", gifFilePath, mp4FilePath);
         try {
+            checkExistsGifFile(gifFilePath);
             ImageSize resizedGifImage = ImageSize.of(gifFilePath).resize();
 
             FFmpegBuilder builder = new FFmpegBuilder()
@@ -47,7 +48,15 @@ public class FFmpegConverter {
             job.run();
             checkExistsMp4File(mp4FilePath);
 
-        } catch (RuntimeException | IOException e) {
+        } catch (IOException e) {
+            log.error("gif파일을 mp4로 변환하는데 실패했습니다.", e);
+            throw new InternalServerErrorException(ErrorType.GIF_MP4_CONVERT_FAIL);
+        }
+    }
+
+    private void checkExistsGifFile(String gifFilePath) {
+        if (Files.notExists(Paths.get(gifFilePath))) {
+            log.error("gif파일이 경로에 존재하지 않습니다.");
             throw new InternalServerErrorException(ErrorType.GIF_MP4_CONVERT_FAIL);
         }
     }

--- a/backend/src/main/java/com/wooteco/nolto/image/infrastructure/FFmpegConverter.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/infrastructure/FFmpegConverter.java
@@ -27,7 +27,7 @@ public class FFmpegConverter {
     public void convertGifToMp4(String gifFilePath, String mp4FilePath) {
         log.info("convert gif to mp4 {} -> {}", gifFilePath, mp4FilePath);
         try {
-            ImageSize gifImageSizeWithResize = ImageSize.resizeOf(gifFilePath);
+            ImageSize resizedGifImage = ImageSize.of(gifFilePath).resize();
 
             FFmpegBuilder builder = new FFmpegBuilder()
                     .setInput(gifFilePath)
@@ -38,15 +38,15 @@ public class FFmpegConverter {
                     .setVideoMovFlags("faststart")
                     .setVideoPixelFormat("yuv420p")
                     .setVideoFilter("scale=trunc(iw/2)*2:trunc(ih/2)*2")
-                    .setVideoWidth(gifImageSizeWithResize.getWidthOnesRounded())
-                    .setVideoHeight(gifImageSizeWithResize.getHeightOnesRounded())
+                    .setVideoWidth(resizedGifImage.getWidthOnesRounded())
+                    .setVideoHeight(resizedGifImage.getHeightOnesRounded())
                     .done();
 
             FFmpegExecutor executor = new FFmpegExecutor(ffmpeg);
             FFmpegJob job = executor.createJob(builder);
             job.run();
-
             checkExistsMp4File(mp4FilePath);
+
         } catch (RuntimeException | IOException e) {
             throw new InternalServerErrorException(ErrorType.GIF_MP4_CONVERT_FAIL);
         }

--- a/backend/src/main/java/com/wooteco/nolto/image/infrastructure/ImageSize.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/infrastructure/ImageSize.java
@@ -24,26 +24,31 @@ public class ImageSize {
 
     private void validateSize(int width, int height) {
         if (width <= 0 && height <= 0) {
-            throw new IllegalArgumentException("이미지의 사이즈는 0보다 커야합니다.");
+            throw new IllegalArgumentException("이미지 사이즈는 0보다 커야합니다.");
         }
     }
 
-    public static ImageSize resizeOf(String filePath) {
-        File gifFile = new File(filePath);
-        BufferedImage read = null;
+    public static ImageSize of(String filePath) {
+        File imageFile = new File(filePath);
+        BufferedImage image = null;
         try {
-            read = ImageIO.read(gifFile);
+            image = ImageIO.read(imageFile);
         } catch (IOException e) {
             throw new InternalServerErrorException(ErrorType.IMAGE_RESIZING_FAIL);
         }
-        int imageWidth = read.getWidth();
-        int imageHeight = read.getHeight();
-        double resizeRatio = calculateResizeRatio(imageWidth, imageHeight);
-
-        return new ImageSize((int) (imageWidth * resizeRatio), (int) (imageHeight * resizeRatio));
+        return of(image);
     }
 
-    private static double calculateResizeRatio(int width, int height) {
+    public static ImageSize of(BufferedImage image) {
+        return new ImageSize(image.getWidth(), image.getHeight());
+    }
+
+    public ImageSize resize() {
+        double resizeRatio = calculateResizeRatio(width, height);
+        return new ImageSize((int) (width * resizeRatio), (int) (height * resizeRatio));
+    }
+
+    private double calculateResizeRatio(int width, int height) {
         if (width <= MAX_PIXEL && height <= MAX_PIXEL) {
             return RESIZE_NOT_NEEDED;
         }
@@ -51,6 +56,10 @@ public class ImageSize {
             return (MAX_PIXEL / height);
         }
         return (MAX_PIXEL / width);
+    }
+
+    public boolean doNotNeedResize(BufferedImage originalImage) {
+        return width == originalImage.getWidth() && height == originalImage.getHeight();
     }
 
     public int getWidthOnesRounded() {

--- a/backend/src/main/java/com/wooteco/nolto/image/infrastructure/ImageSize.java
+++ b/backend/src/main/java/com/wooteco/nolto/image/infrastructure/ImageSize.java
@@ -2,12 +2,14 @@ package com.wooteco.nolto.image.infrastructure;
 
 import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.exception.InternalServerErrorException;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 
+@Slf4j
 public class ImageSize {
 
     private static final double MAX_PIXEL = 400.0;
@@ -24,19 +26,20 @@ public class ImageSize {
 
     private void validateSize(int width, int height) {
         if (width <= 0 && height <= 0) {
-            throw new IllegalArgumentException("이미지 사이즈는 0보다 커야합니다.");
+            log.error("이미지 사이즈는 0보다 커야합니다.");
+            throw new InternalServerErrorException(ErrorType.IMAGE_RESIZING_FAIL);
         }
     }
 
     public static ImageSize of(String filePath) {
         File imageFile = new File(filePath);
-        BufferedImage image = null;
         try {
-            image = ImageIO.read(imageFile);
+            return of(ImageIO.read(imageFile));
         } catch (IOException e) {
+            log.error("이미지 파일을 읽는데 실패했습니다.", e);
             throw new InternalServerErrorException(ErrorType.IMAGE_RESIZING_FAIL);
         }
-        return of(image);
+
     }
 
     public static ImageSize of(BufferedImage image) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -40,10 +40,6 @@ server:
 application:
   cors:
     allow-origin: "*"
-ffmpeg:
-  path: /usr/bin/ffmpeg
-ffprobe:
-  path: /usr/bin/ffprobe
 ---
 spring:
   config:

--- a/backend/src/test/java/com/wooteco/nolto/image/application/ImageConvertServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/image/application/ImageConvertServiceTest.java
@@ -2,21 +2,18 @@ package com.wooteco.nolto.image.application;
 
 import com.wooteco.nolto.image.config.FFmpegConfig;
 import com.wooteco.nolto.image.infrastructure.FFmpegConverter;
-import net.bramp.ffmpeg.FFmpeg;
-import net.bramp.ffmpeg.job.FFmpegJob;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,20 +27,14 @@ class ImageConvertServiceTest {
     @MockBean
     private FFmpegConverter ffmpegConverter;
 
-    @MockBean
-    private FFmpegConfig ffmpegConfig;
-
-    @MockBean
-    private FFmpegJob ffmpegJob;
-
     @BeforeEach
-    void setUp() throws IOException {
-        given(ffmpegConfig.ffmpeg()).willReturn(new FFmpeg());
+    void setUp() {
         willDoNothing().given(ffmpegConverter).convertGifToMp4(anyString(), anyString());
     }
 
+    @DisplayName("gif 파일을 mp4파일로 변환한다.")
     @Test
-    void convertGifToMp4() throws IOException {
+    void convertGifToMp4() {
         // given
         String gifFileName = "jjv1FK.gif";
         URL resource = getClass().getClassLoader().getResource("static/" + gifFileName);
@@ -57,7 +48,6 @@ class ImageConvertServiceTest {
         assertThat(mp4FileName).isEqualTo(expectedFileName);
 
         // then
-        verify(ffmpegConfig, times(1)).ffmpeg();
         verify(ffmpegConverter, times(1)).convertGifToMp4(anyString(), anyString());
     }
 }

--- a/backend/src/test/java/com/wooteco/nolto/image/application/ImageConvertServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/image/application/ImageConvertServiceTest.java
@@ -3,7 +3,7 @@ package com.wooteco.nolto.image.application;
 import com.wooteco.nolto.image.config.FFmpegConfig;
 import com.wooteco.nolto.image.infrastructure.FFmpegConverter;
 import net.bramp.ffmpeg.FFmpeg;
-import net.bramp.ffmpeg.FFprobe;
+import net.bramp.ffmpeg.job.FFmpegJob;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,12 +15,14 @@ import java.io.IOException;
 import java.net.URL;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @SpringBootTest(classes = {ImageConvertService.class, FFmpegConfig.class, FFmpegConverter.class})
 class ImageConvertServiceTest {
-
-    private final String gifFileName = "jjv1FK.gif";
 
     @Autowired
     private ImageConvertService imageConvertService;
@@ -31,26 +33,31 @@ class ImageConvertServiceTest {
     @MockBean
     private FFmpegConfig ffmpegConfig;
 
+    @MockBean
+    private FFmpegJob ffmpegJob;
+
     @BeforeEach
     void setUp() throws IOException {
         given(ffmpegConfig.ffmpeg()).willReturn(new FFmpeg());
-        given(ffmpegConfig.ffprobe()).willReturn(new FFprobe());
         willDoNothing().given(ffmpegConverter).convertGifToMp4(anyString(), anyString());
     }
 
     @Test
-    void convertGifToMp4() {
+    void convertGifToMp4() throws IOException {
         // given
+        String gifFileName = "jjv1FK.gif";
         URL resource = getClass().getClassLoader().getResource("static/" + gifFileName);
         String gifFilePath = resource.getPath();
         File gifFile = new File(gifFilePath);
 
         // when
         File mp4File = imageConvertService.convertGifToMp4(gifFile);
-
-        // then
         String mp4FileName = mp4File.getName();
         String expectedFileName = "jjv1FK.mp4";
         assertThat(mp4FileName).isEqualTo(expectedFileName);
+
+        // then
+        verify(ffmpegConfig, times(1)).ffmpeg();
+        verify(ffmpegConverter, times(1)).convertGifToMp4(anyString(), anyString());
     }
 }

--- a/backend/src/test/java/com/wooteco/nolto/image/application/adapter/ImageHandlerAdapterTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/image/application/adapter/ImageHandlerAdapterTest.java
@@ -5,8 +5,8 @@ import com.wooteco.nolto.image.application.ImageResizeService;
 import com.wooteco.nolto.image.config.FFmpegConfig;
 import com.wooteco.nolto.image.domain.ProcessedImage;
 import com.wooteco.nolto.image.infrastructure.FFmpegConverter;
-import net.bramp.ffmpeg.FFmpeg;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,9 +19,9 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 
+@DisplayName("ImageHandlerAdapterTest 테스트")
 @SpringBootTest(classes = {ImageResizeHandler.class, ImageConvertHandler.class,
         ImageResizeService.class, ImageConvertService.class, FFmpegConverter.class, FFmpegConfig.class})
 class ImageHandlerAdapterTest {
@@ -32,18 +32,15 @@ class ImageHandlerAdapterTest {
     @MockBean
     private FFmpegConverter ffmpegConverter;
 
-    @MockBean
-    private FFmpegConfig ffmpegConfig;
-
     @BeforeEach
     void setUp() throws IOException {
-        given(ffmpegConfig.ffmpeg()).willReturn(new FFmpeg());
         willDoNothing().given(ffmpegConverter).convertGifToMp4(anyString(), anyString());
     }
 
     private final String gifFileName = "jjv1FK.gif";
     private final String pngFileName = "pretty_cat.png";
 
+    @DisplayName(".gif 확장자인 파일이 아니라면 ImageResizeHandler를 사용한다.")
     @Test
     void imageResizeHandler() {
         // given
@@ -62,6 +59,7 @@ class ImageHandlerAdapterTest {
         assertThat(resizedFile).hasName(expectedFileName);
     }
 
+    @DisplayName(".gif 확장자인 파일이라면 ImageConvertHandler를 사용한다.")
     @Test
     void imageConvertHandler() {
         // given

--- a/backend/src/test/java/com/wooteco/nolto/image/application/adapter/ImageHandlerAdapterTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/image/application/adapter/ImageHandlerAdapterTest.java
@@ -6,7 +6,6 @@ import com.wooteco.nolto.image.config.FFmpegConfig;
 import com.wooteco.nolto.image.domain.ProcessedImage;
 import com.wooteco.nolto.image.infrastructure.FFmpegConverter;
 import net.bramp.ffmpeg.FFmpeg;
-import net.bramp.ffmpeg.FFprobe;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +38,6 @@ class ImageHandlerAdapterTest {
     @BeforeEach
     void setUp() throws IOException {
         given(ffmpegConfig.ffmpeg()).willReturn(new FFmpeg());
-        given(ffmpegConfig.ffprobe()).willReturn(new FFprobe());
         willDoNothing().given(ffmpegConverter).convertGifToMp4(anyString(), anyString());
     }
 

--- a/backend/src/test/java/com/wooteco/nolto/image/infrastructure/FFmpegConverterTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/image/infrastructure/FFmpegConverterTest.java
@@ -2,6 +2,7 @@ package com.wooteco.nolto.image.infrastructure;
 
 import com.wooteco.nolto.image.config.FFmpegConfig;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -24,10 +25,15 @@ class FFmpegConverterTest {
 
     @AfterEach
     void tearDown() throws IOException {
+        변환_후_생성된_파일삭제();
+    }
+
+    private void 변환_후_생성된_파일삭제() throws IOException {
         URL resource = getClass().getClassLoader().getResource("static/" + mp4FileName);
         Files.delete(Paths.get(resource.getPath()));
     }
 
+    @DisplayName("ffmpeg 명령어를 사용해서 gif파일을 mp4 파일로 변환한다.")
     @Test
     void convertGifToMp4() {
         // given

--- a/backend/src/test/java/com/wooteco/nolto/image/infrastructure/FFmpegConverterTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/image/infrastructure/FFmpegConverterTest.java
@@ -1,5 +1,6 @@
 package com.wooteco.nolto.image.infrastructure;
 
+import com.wooteco.nolto.exception.InternalServerErrorException;
 import com.wooteco.nolto.image.config.FFmpegConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,8 +12,10 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest(classes = {FFmpegConverter.class, FFmpegConfig.class})
 class FFmpegConverterTest {
@@ -30,7 +33,9 @@ class FFmpegConverterTest {
 
     private void 변환_후_생성된_파일삭제() throws IOException {
         URL resource = getClass().getClassLoader().getResource("static/" + mp4FileName);
-        Files.delete(Paths.get(resource.getPath()));
+        if (Objects.nonNull(resource)) {
+            Files.delete(Paths.get(resource.getPath()));
+        }
     }
 
     @DisplayName("ffmpeg 명령어를 사용해서 gif파일을 mp4 파일로 변환한다.")
@@ -46,7 +51,36 @@ class FFmpegConverterTest {
         // when
         ffmpegConverter.convertGifToMp4(gifFilePath, mp4FilePath);
 
+        // then
         URL mp4URL = getClass().getClassLoader().getResource("static/" + mp4FileName);
         assertThat(mp4URL.getPath()).isEqualTo(mp4FilePath);
+    }
+
+    @DisplayName("gif파일이 파일 경로에 존재하지 않으면 예외가 발생한다. ")
+    @Test
+    void convertGifToMp4WithInvalidGifFilePath() {
+        // given
+        String gifFilePath = "static/매우잘못된경로에있는파일.gif";
+        int indexOfExtensionDot = gifFilePath.lastIndexOf(".");
+        String filePathWithoutExtension = gifFilePath.substring(0, indexOfExtensionDot);
+        String mp4FilePath = filePathWithoutExtension + ".mp4";
+
+        // when then
+        assertThatThrownBy(() -> ffmpegConverter.convertGifToMp4(gifFilePath, mp4FilePath))
+                .isInstanceOf(InternalServerErrorException.class)
+                .hasMessage("gif파일을 mp4파일로 변환에 실패하였습니다.");
+    }
+
+    @DisplayName("gif파일이 파일 경로에 존재하지 않으면 예외가 발생한다. ")
+    @Test
+    void convertGifToMp4WithInvalidMp4FilePath() {
+        // given
+        URL resource = getClass().getClassLoader().getResource("static/" + gifFileName);
+        String gifFilePath = resource.getPath();
+        String mp4FilePath = "static/이런경로가없는데/매우잘못된경로에있는파일.mp4";
+
+        // when then
+        assertThatThrownBy(() -> ffmpegConverter.convertGifToMp4(gifFilePath, mp4FilePath))
+                .isInstanceOf(RuntimeException.class);
     }
 }

--- a/backend/src/test/java/com/wooteco/nolto/image/infrastructure/FFmpegConverterTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/image/infrastructure/FFmpegConverterTest.java
@@ -1,23 +1,32 @@
 package com.wooteco.nolto.image.infrastructure;
 
 import com.wooteco.nolto.image.config.FFmpegConfig;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled
 @SpringBootTest(classes = {FFmpegConverter.class, FFmpegConfig.class})
 class FFmpegConverterTest {
 
     private final String gifFileName = "jjv1FK.gif";
+    private final String mp4FileName = "jjv1FK.mp4";
 
     @Autowired
     private FFmpegConverter ffmpegConverter;
+
+    @AfterEach
+    void tearDown() throws IOException {
+        URL resource = getClass().getClassLoader().getResource("static/" + mp4FileName);
+        Files.delete(Paths.get(resource.getPath()));
+    }
 
     @Test
     void convertGifToMp4() {
@@ -29,6 +38,9 @@ class FFmpegConverterTest {
         String mp4FilePath = filePathWithoutExtension + ".mp4";
 
         // when
-        assertDoesNotThrow(() -> ffmpegConverter.convertGifToMp4(gifFilePath, mp4FilePath));
+        ffmpegConverter.convertGifToMp4(gifFilePath, mp4FilePath);
+
+        URL mp4URL = getClass().getClassLoader().getResource("static/" + mp4FileName);
+        assertThat(mp4URL.getPath()).isEqualTo(mp4FilePath);
     }
 }


### PR DESCRIPTION
## 작업 내용
* FFmpeg를 애플리케이션이 jar로 관리하도록 수정
  - 이를 위한 의존성 추가
  - org.bytedeco.javacpp : JNI 코드를 생성하고 C++ 컴파일러에게 전달하여 네이티브 라이브러리를 빌드합니다.
  - org.bytedeco.ffmpeg : 실행할 수 있는 ffmpeg를 추출할 수 있습니다.
  - org.bytedeco.javacv-platform : OpenCV, FFmpeg 등의 자주 사용하는 라이브러리들을 다양한 플랫폼(운영체제)에 적절한 jar를 제공합니다.
* application.yml에 FFmpeg에 관한 설정 삭제
* 테스트 수정

~~정상인의 수면패턴에 들어가기위해 자세한 내용은 일어나서 정리할게요 🙇~~
[[Java] FFmpeg로 gif파일 mp4로 변환하기 - 2](https://parkadd.tistory.com/126)

Closes #589 

## 주의사항
FFmpeg path 설정은 처리했으니 안심하고 테스트 돌리라구
![image](https://user-images.githubusercontent.com/57378410/135135799-75228c04-28e3-4741-849a-52bc665edcf6.png)
