### PR TITLE
feat: refresh token을 통한 토큰 재발급

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -64,6 +64,9 @@ dependencies {
 
     // slack
     implementation 'com.github.maricn:logback-slack-appender:1.4.0'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 ext {

--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -31,3 +31,51 @@ include::{snippets}/auth-oAuthSignIn/http-response.adoc[]
 ==== Response Fields
 
 include::{snippets}/auth-oAuthSignIn/response-fields.adoc[]
+
+=== 토큰 재발급 요청
+
+==== Request
+
+include::{snippets}/auth-refreshToken/http-request.adoc[]
+
+include::{snippets}/auth-refreshToken/request-fields.adoc[]
+
+==== Response
+
+include::{snippets}/auth-refreshToken/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/auth-refreshToken/response-fields.adoc[]
+
+=== 잘못된 리프레시 토큰으로 재발급 요청
+
+==== Request
+
+include::{snippets}/auth-invalidRefreshToken/http-request.adoc[]
+
+include::{snippets}/auth-invalidRefreshToken/request-fields.adoc[]
+
+==== Response
+
+include::{snippets}/auth-invalidRefreshToken/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/auth-invalidRefreshToken/response-fields.adoc[]
+
+=== 잘못된 클라이언트의 리프레시 토큰 재발급 요청
+
+==== Request
+
+include::{snippets}/auth-invalidClient-RefreshToken/http-request.adoc[]
+
+include::{snippets}/auth-invalidClient-RefreshToken/request-fields.adoc[]
+
+==== Response
+
+include::{snippets}/auth-invalidClient-RefreshToken/http-response.adoc[]
+
+==== Response Fields
+
+include::{snippets}/auth-invalidClient-RefreshToken/response-fields.adoc[]

--- a/backend/src/main/java/com/wooteco/nolto/auth/infrastructure/RedisUtil.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/infrastructure/RedisUtil.java
@@ -1,0 +1,29 @@
+package com.wooteco.nolto.auth.infrastructure;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class RedisUtil {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisUtil(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public String get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void set(String key, String value, long expiredIn) {
+        redisTemplate.opsForValue().set(key, value, expiredIn, TimeUnit.SECONDS);
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+}
+

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/OAuthController.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/OAuthController.java
@@ -2,16 +2,18 @@ package com.wooteco.nolto.auth.ui;
 
 import com.wooteco.nolto.auth.application.AuthService;
 import com.wooteco.nolto.auth.ui.dto.OAuthRedirectResponse;
+import com.wooteco.nolto.auth.ui.dto.RefreshTokenRequest;
 import com.wooteco.nolto.auth.ui.dto.TokenResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class OAuthController {
     private final AuthService authService;
 
@@ -21,8 +23,17 @@ public class OAuthController {
     }
 
     @GetMapping("login/oauth/{socialType}/token")
-    public ResponseEntity<TokenResponse> signInOAuth(@PathVariable String socialType, @RequestParam String code) {
-        TokenResponse tokenResponse = authService.oAuthSignIn(socialType, code);
+    public ResponseEntity<TokenResponse> signInOAuth(@PathVariable String socialType,
+                                                     @RequestParam String code,
+                                                     HttpServletRequest request) {
+        log.info("Remote Address : {}", request.getLocalAddr());
+        TokenResponse tokenResponse = authService.oAuthSignIn(socialType, code, request.getRemoteAddr());
+        return ResponseEntity.ok(tokenResponse);
+    }
+
+    @PostMapping("login/oauth/refreshToken")
+    public ResponseEntity<TokenResponse> generateRefreshToken(@RequestBody RefreshTokenRequest request) {
+        TokenResponse tokenResponse = authService.refreshToken(request);
         return ResponseEntity.ok(tokenResponse);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/RefreshTokenRequest.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/RefreshTokenRequest.java
@@ -1,0 +1,19 @@
+package com.wooteco.nolto.auth.ui.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RefreshTokenRequest {
+
+    private long userId;
+    private String refreshToken;
+    private String clientIP;
+
+    public RefreshTokenRequest(long userId, String refreshToken, String clientIP) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+        this.clientIP = clientIP;
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/RefreshTokenResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/RefreshTokenResponse.java
@@ -1,0 +1,15 @@
+package com.wooteco.nolto.auth.ui.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenResponse {
+
+    private final String token;
+    private final long expiredIn;
+
+    public RefreshTokenResponse(String token, long expiredIn) {
+        this.token = token;
+        this.expiredIn = expiredIn;
+    }
+}

--- a/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/TokenResponse.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/ui/dto/TokenResponse.java
@@ -7,8 +7,16 @@ import lombok.Setter;
 @Setter
 public class TokenResponse {
     private String accessToken;
+    private String refreshToken;
+    private Long expiredIn;
 
-    public TokenResponse(String accessToken) {
+    public TokenResponse(String accessToken, String refreshToken, Long expiredIn) {
         this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.expiredIn = expiredIn;
+    }
+
+    public static TokenResponse of(String accessToken, RefreshTokenResponse refreshToken) {
+        return new TokenResponse(accessToken, refreshToken.getToken(), refreshToken.getExpiredIn());
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/exception/ErrorType.java
+++ b/backend/src/main/java/com/wooteco/nolto/exception/ErrorType.java
@@ -16,6 +16,7 @@ public enum ErrorType {
     USER_NOT_FOUND("auth-004", "존재하지 않는 유저입니다."),
     NOT_SUPPORTED_SOCIAL_LOGIN("auth-005", "지원하지 않는 소셜 로그인입니다."),
     SOCIAL_LOGIN_CONNECTION_FAIL("auth-006", "소셜 로그인 연동에 실패했습니다."),
+    INVALID_CLIENT("auth-007", "권한이 없는 클라이언트의 요청입니다."),
 
     FEED_NOT_FOUND("feed-001", "존재하지 않는 피드입니다."),
     MISSING_DEPLOY_URL("feed-002", "전시 중 피드는 deployUrl이 필수입니다."),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -30,6 +30,13 @@ spring:
   web:
     resources:
       add-mappings: false
+  redis:
+    host: 127.0.0.1
+    port: 6379
+  data:
+    redis:
+      repositories:
+        enabled: false
 server:
   compression:
     enabled: true

--- a/backend/src/test/java/com/wooteco/nolto/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/acceptance/AcceptanceTest.java
@@ -2,6 +2,7 @@ package com.wooteco.nolto.acceptance;
 
 import com.wooteco.nolto.auth.domain.SocialType;
 import com.wooteco.nolto.auth.infrastructure.JwtTokenProvider;
+import com.wooteco.nolto.auth.ui.dto.RefreshTokenResponse;
 import com.wooteco.nolto.auth.ui.dto.TokenResponse;
 import com.wooteco.nolto.feed.ui.dto.FeedRequest;
 import com.wooteco.nolto.image.application.ImageKind;
@@ -16,6 +17,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
 
 import static com.wooteco.nolto.acceptance.FeedAcceptanceTest.피드_작성_요청;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,7 +71,8 @@ public abstract class AcceptanceTest {
         User 저장된_엄청난_유저 = 회원_등록되어_있음(user);
 
         String token = jwtTokenProvider.createToken(String.valueOf(저장된_엄청난_유저.getId()));
-        return new TokenResponse(token);
+        RefreshTokenResponse refreshTokenResponse = jwtTokenProvider.createRefreshToken(UUID.randomUUID().toString());
+        return TokenResponse.of(token, refreshTokenResponse);
     }
 
     public User 회원_등록되어_있음(User user) {

--- a/backend/src/test/java/com/wooteco/nolto/api/OAuthControllerTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/api/OAuthControllerTest.java
@@ -2,18 +2,24 @@ package com.wooteco.nolto.api;
 
 import com.wooteco.nolto.auth.ui.OAuthController;
 import com.wooteco.nolto.auth.ui.dto.OAuthRedirectResponse;
+import com.wooteco.nolto.auth.ui.dto.RefreshTokenRequest;
 import com.wooteco.nolto.auth.ui.dto.TokenResponse;
+import com.wooteco.nolto.exception.BadRequestException;
+import com.wooteco.nolto.exception.ErrorType;
+import com.wooteco.nolto.exception.UnauthorizedException;
+import com.wooteco.nolto.exception.dto.ExceptionResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -21,11 +27,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = OAuthController.class)
 class OAuthControllerTest extends ControllerTest {
 
-    private static final OAuthRedirectResponse OAUTH_REDIRECT_RESPONSE = new OAuthRedirectResponse("client_id", "redirect_uri", "scope", "response_type");
-    private static final TokenResponse TOKEN_RESPONSE =
-            new TokenResponse("eefaccesstoken123");
     private static final String SOCIAL_TYPE_NAME = "github";
     private static final String CODE = "code";
+    private static final long EXPIRES_IN = 24 * 60 * 60 * 14L;
+
+    public static final RefreshTokenRequest REFRESH_TOKEN_REQUEST =
+            new RefreshTokenRequest(1L, "refresh token value", "127.0.0.1");
+    private static final OAuthRedirectResponse OAUTH_REDIRECT_RESPONSE =
+            new OAuthRedirectResponse("client_id", "redirect_uri", "scope", "response_type");
+    private static final TokenResponse TOKEN_RESPONSE =
+            new TokenResponse("access token value", "refresh token value", EXPIRES_IN);
 
     @DisplayName("소셜 로그인을 기능 요청의 code 값을 얻기 위한 파라미터 반환해준다.")
     @Test
@@ -33,9 +44,9 @@ class OAuthControllerTest extends ControllerTest {
         given(authService.requestSocialRedirect(SOCIAL_TYPE_NAME)).willReturn(OAUTH_REDIRECT_RESPONSE);
 
         mockMvc.perform(
-                get("/login/oauth/{socialType}", SOCIAL_TYPE_NAME)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON))
+                        get("/login/oauth/{socialType}", SOCIAL_TYPE_NAME)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(OAUTH_REDIRECT_RESPONSE)))
                 .andDo(document("auth-requestSocialRedirect",
@@ -56,12 +67,17 @@ class OAuthControllerTest extends ControllerTest {
     @DisplayName("소셜로그인 측에서 발급한 코드를 받아 소셜로그인을 완료하고, 백엔드 자체의 토큰을 발급한다.")
     @Test
     void oAuthSignIn() throws Exception {
-        given(authService.oAuthSignIn(SOCIAL_TYPE_NAME, "code")).willReturn(TOKEN_RESPONSE);
+        given(authService.oAuthSignIn(SOCIAL_TYPE_NAME, "code", "127.0.0.1")).willReturn(TOKEN_RESPONSE);
 
         mockMvc.perform(
-                get("/login/oauth/{socialType}/token", SOCIAL_TYPE_NAME).param("code", CODE)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON))
+                        get("/login/oauth/{socialType}/token", SOCIAL_TYPE_NAME)
+                                .param("code", CODE)
+                                .with(request -> {
+                                    request.setRemoteAddr("127.0.0.1");
+                                    return request;
+                                })
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(TOKEN_RESPONSE)))
                 .andDo(document("auth-oAuthSignIn",
@@ -74,7 +90,103 @@ class OAuthControllerTest extends ControllerTest {
                                 parameterWithName("socialType").description("소셜 서비스 이름")
                         ),
                         responseFields(
-                                fieldWithPath("accessToken").type(JsonFieldType.STRING).description("액세스 토큰")
+                                fieldWithPath("accessToken").type(JsonFieldType.STRING).description("액세스 토큰"),
+                                fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰"),
+                                fieldWithPath("expiredIn").type(JsonFieldType.NUMBER).description("리프레시 토큰 만료 시간")
+                        )
+                ));
+    }
+
+    @DisplayName("리프레시 토큰을 사용해 리프레시 토큰, 액세스 토큰을 재발급한다.")
+    @Test
+    void refreshToken() throws Exception {
+        given(authService.refreshToken(any())).willReturn(TOKEN_RESPONSE);
+
+        mockMvc.perform(
+                        post("/login/oauth/refreshToken")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(REFRESH_TOKEN_REQUEST))
+                                .with(servletRequest -> {
+                                    servletRequest.setRemoteAddr("127.0.0.1");
+                                    return servletRequest;
+                                }))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(TOKEN_RESPONSE)))
+                .andDo(document("auth-refreshToken",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestFields(
+                                fieldWithPath("userId").type(JsonFieldType.NUMBER).description("재발급받을 유저의 id"),
+                                fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰 (이후 재사용 X)"),
+                                fieldWithPath("clientIP").type(JsonFieldType.STRING).description("요청한 클라이언트의 IP")
+                        ),
+                        responseFields(
+                                fieldWithPath("accessToken").type(JsonFieldType.STRING).description("재발급한 액세스 토큰"),
+                                fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("재발급한 리프레시 토큰"),
+                                fieldWithPath("expiredIn").type(JsonFieldType.NUMBER).description("리프레시 토큰 만료 시간")
+                        )
+                ));
+    }
+
+    @DisplayName("리프레시 토큰 발급 시 리프레시 토큰 입력이 잘못된 경우 예외처리한다.")
+    @Test
+    void invalidRefreshToken() throws Exception {
+        given(authService.refreshToken(any())).willThrow(new BadRequestException(ErrorType.INVALID_TOKEN));
+
+        mockMvc.perform(
+                        post("/login/oauth/refreshToken")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(REFRESH_TOKEN_REQUEST))
+                                .with(servletRequest -> {
+                                    servletRequest.setRemoteAddr("1.1.1.1");
+                                    return servletRequest;
+                                }))
+                .andExpect(status().is4xxClientError())
+                .andExpect(content().json(objectMapper.writeValueAsString(ExceptionResponse.of(ErrorType.INVALID_TOKEN))))
+                .andDo(document("auth-invalidRefreshToken",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestFields(
+                                fieldWithPath("userId").type(JsonFieldType.NUMBER).description("재발급받을 유저의 id"),
+                                fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("잘못된 리프레시 토큰"),
+                                fieldWithPath("clientIP").type(JsonFieldType.STRING).description("요청한 클라이언트의 IP")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorCode").type(JsonFieldType.STRING).description("에러 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메세지")
+                        )
+                ));
+    }
+
+    @DisplayName("리프레시 토큰 발급 시 잘못된 클라이언트 IP로 요청된 경우 예외처리한다.")
+    @Test
+    void invalidClientIP() throws Exception {
+        given(authService.refreshToken(any())).willThrow(new UnauthorizedException(ErrorType.INVALID_CLIENT));
+
+        mockMvc.perform(
+                        post("/login/oauth/refreshToken")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(REFRESH_TOKEN_REQUEST))
+                                .with(servletRequest -> {
+                                    servletRequest.setRemoteAddr("127.0.0.1");
+                                    return servletRequest;
+                                }))
+                .andExpect(status().is4xxClientError())
+                .andExpect(content().json(objectMapper.writeValueAsString(ExceptionResponse.of(ErrorType.INVALID_CLIENT))))
+                .andDo(document("auth-invalidClient-RefreshToken",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestFields(
+                                fieldWithPath("userId").type(JsonFieldType.NUMBER).description("재발급받을 유저의 id"),
+                                fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰. (이후 재사용될 수 없음)"),
+                                fieldWithPath("clientIP").type(JsonFieldType.STRING).description("권한이 없는 클라이언트의 IP")
+                        ),
+                        responseFields(
+                                fieldWithPath("errorCode").type(JsonFieldType.STRING).description("에러 코드"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("에러 메세지")
                         )
                 ));
     }

--- a/backend/src/test/java/com/wooteco/nolto/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/auth/application/AuthServiceTest.java
@@ -2,10 +2,12 @@ package com.wooteco.nolto.auth.application;
 
 import com.wooteco.nolto.auth.domain.OAuthClientProvider;
 import com.wooteco.nolto.auth.domain.SocialType;
+import com.wooteco.nolto.auth.infrastructure.RedisUtil;
 import com.wooteco.nolto.auth.infrastructure.oauth.GithubClient;
 import com.wooteco.nolto.auth.infrastructure.oauth.GoogleClient;
 import com.wooteco.nolto.auth.ui.dto.OAuthRedirectResponse;
 import com.wooteco.nolto.auth.ui.dto.OAuthTokenResponse;
+import com.wooteco.nolto.auth.ui.dto.RefreshTokenRequest;
 import com.wooteco.nolto.auth.ui.dto.TokenResponse;
 import com.wooteco.nolto.exception.BadRequestException;
 import com.wooteco.nolto.exception.ErrorType;
@@ -33,6 +35,7 @@ class AuthServiceTest {
     public static final String USER_NICKNAME = "user";
     private static final User USER1 = new User("socialId1", SocialType.GITHUB, USER_NICKNAME, "imageUrl");
     private static final User USER2 = new User("socialId2", SocialType.GITHUB, USER_NICKNAME, "imageUrl");
+    private static final String CLIENT_IP_V6 = "0:0:0:0:0:0:0:1";
 
     @Autowired
     private AuthService authService;
@@ -48,6 +51,9 @@ class AuthServiceTest {
 
     @MockBean
     private GoogleClient googleClient;
+
+    @MockBean
+    private RedisUtil redisUtil;
 
     @DisplayName("깃허브 로그인의 code를 얻기위한 파라미터들을 요청한다.")
     @Test
@@ -85,8 +91,7 @@ class AuthServiceTest {
         given(githubClient.generateAccessToken("code")).willReturn(OAUTH_TOKEN_RESPONSE1);
         given(githubClient.generateUserInfo(OAUTH_TOKEN_RESPONSE1)).willReturn(USER1);
 
-        TokenResponse tokenResponse = authService.oAuthSignIn("github", "code");
-
+        TokenResponse tokenResponse = authService.oAuthSignIn("github", "code", CLIENT_IP_V6);
         assertThat(tokenResponse).isNotNull();
     }
 
@@ -97,8 +102,7 @@ class AuthServiceTest {
         given(githubClient.generateAccessToken("code")).willReturn(OAUTH_TOKEN_RESPONSE1);
         given(githubClient.generateUserInfo(OAUTH_TOKEN_RESPONSE1)).willReturn(USER1);
 
-        TokenResponse tokenResponse = authService.oAuthSignIn("google", "code");
-
+        TokenResponse tokenResponse = authService.oAuthSignIn("google", "code", CLIENT_IP_V6);
         assertThat(tokenResponse).isNotNull();
     }
 
@@ -109,11 +113,11 @@ class AuthServiceTest {
         given(githubClient.generateAccessToken("code")).willReturn(OAUTH_TOKEN_RESPONSE1);
         given(githubClient.generateUserInfo(OAUTH_TOKEN_RESPONSE1)).willReturn(USER1);
 
-        assertThatThrownBy(() -> authService.oAuthSignIn("google", null))
+        assertThatThrownBy(() -> authService.oAuthSignIn("google", null, CLIENT_IP_V6))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorType.INVALID_OAUTH_CODE.getMessage());
 
-        assertThatThrownBy(() -> authService.oAuthSignIn("google", ""))
+        assertThatThrownBy(() -> authService.oAuthSignIn("google", "", CLIENT_IP_V6))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorType.INVALID_OAUTH_CODE.getMessage());
     }
@@ -125,7 +129,7 @@ class AuthServiceTest {
         given(githubClient.generateAccessToken("code")).willReturn(OAUTH_TOKEN_RESPONSE1);
         given(githubClient.generateUserInfo(OAUTH_TOKEN_RESPONSE1)).willReturn(USER1);
 
-        assertThatThrownBy(() -> authService.oAuthSignIn("naver", "code"))
+        assertThatThrownBy(() -> authService.oAuthSignIn("naver", "code", CLIENT_IP_V6))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorType.NOT_SUPPORTED_SOCIAL_LOGIN.getMessage());
     }
@@ -142,8 +146,8 @@ class AuthServiceTest {
         User existNickNameUser = new User("socialId3", SocialType.GITHUB, USER_NICKNAME, "imageUrl");
         userRepository.save(existNickNameUser);
 
-        authService.oAuthSignIn("google", "code1");
-        authService.oAuthSignIn("google", "code2");
+        authService.oAuthSignIn("google", "code1", CLIENT_IP_V6);
+        authService.oAuthSignIn("google", "code2", CLIENT_IP_V6);
 
         boolean 맨처음_저장된_중복_닉네임_존재여부 = userRepository.existsByNickName(USER_NICKNAME);
         boolean 두번째_저장된_중복_닉네임_존재여부 = userRepository.existsByNickName(USER_NICKNAME + "(1)");
@@ -152,5 +156,20 @@ class AuthServiceTest {
         assertThat(맨처음_저장된_중복_닉네임_존재여부).isTrue();
         assertThat(두번째_저장된_중복_닉네임_존재여부).isTrue();
         assertThat(세번째_저장된_중복_닉네임_존재여부).isTrue();
+    }
+
+    @DisplayName("리프레시 토큰을 이용해 액세스/리프레시 토큰을 재발급 한다.")
+    @Test
+    void refreshToken() {
+        // given
+        given(redisUtil.get("refresh token")).willReturn("client IP");
+
+        // when
+        TokenResponse tokenResponse = authService.refreshToken(new RefreshTokenRequest(1L, "refresh token", "client IP"));
+
+        // then
+        assertThat(tokenResponse.getRefreshToken()).isNotNull();
+        assertThat(tokenResponse.getAccessToken()).isNotNull();
+        assertThat(tokenResponse.getExpiredIn()).isNotNull();
     }
 }


### PR DESCRIPTION
## 작업 내용

- [간단한 SSR 이해하기](https://pomo0703.tistory.com/206)
- [간단한 쿠키 옵션 이해하기](https://pomo0703.tistory.com/207)
- [Refresh Token 적용 과정](https://pomo0703.tistory.com/208)

### Refresh Token 적용

- 리프레시 토큰 발급에 대한 api 작성
  - 리프레시 토큰 정상 발급
  - 잘못된 리프레시 토큰으로 재발급 요청
  - 잘못된 클라이언트 IP로 재발급 요청
- ErrorType 추가 (`auth-007`)

### redis 적용

- 최대 메모리 사양 1G
- 최대 사용 메모리 초과 시 오래된 데이터를 지우고, 가장 최근 데이터를 저장하도록 설정


- 레포지토리에서는 redis를 사용하지 않으므로 다음과 같은 로그가 뜹니다.

```
Spring Data Redis - Could not safely identify store assignment for repository...
```

   👉 `spring.data.redis.repositories.enabled =false` 로 설정하여 해결


- Closes #599 and #600

## 주의사항

- 내장형 레디스를 이용해 테스트를 진행하려고 했으나 [M1에서 내장형 레디스 이슈](https://velog.io/@hakjong/ARM-Mac-M1-%EC%97%90%EC%84%9C-embedded-redis-%EC%82%AC%EC%9A%A9)로 우선 mocking

![image](https://user-images.githubusercontent.com/34594339/135826797-8d2690ec-a4f0-4e08-8fca-bf543c3e5e50.png)


![image](https://user-images.githubusercontent.com/34594339/135826848-f85dc6db-52d5-4a0c-b7f1-0d2e4609fec8.png)

해당 글처럼 바이너리 파일을 가져와 프로젝트에 적용하려고 했으나 실패 ㅠㅠ 추후 재적용 논의필요!!
**로컬에서 redis 구동하여 제대로 작동하는 것은 확인하였습니다!**



- **allow-origin에 프론트 SSR 서버 접근 권한 허용 필요 (prod가 아마 막혀있을 것.)**