### PR TITLE
[FE] fix: snackbar portal을 클라이언트에서 렌더링하도록 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,13 +9,18 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import ErrorFallback from 'components/ErrorFallback/ErrorFallback';
 import DialogProvider from 'contexts/dialog/DialogProvider';
 import ModalProvider from 'contexts/modal/ModalProvider';
-import SnackbarProvider from 'contexts/snackbar/SnackbarProvider';
 import MemberProvider from 'contexts/member/MemberProvider';
 import ROUTE from 'constants/routes';
 import { ERROR_MSG } from 'constants/message';
 import useTheme from 'hooks/useTheme';
 import GlobalStyle from './Global.styles';
 import { defaultTheme, thanksgivingTheme } from '../themes';
+import loadable from '@loadable/component';
+
+const SnackbarProvider = loadable(
+  () => import(/* webpackChunkName: "SnackbarProvider" */ 'contexts/snackbar/SnackbarProvider'),
+  { ssr: false },
+);
 
 const App = () => {
   const [themeMode, toggleThemeMode] = useTheme();

--- a/frontend/src/constants/windowDetector.ts
+++ b/frontend/src/constants/windowDetector.ts
@@ -1,3 +1,3 @@
-const hasWindow = typeof window !== 'undefined' ? true : false;
+const hasWindow = typeof window !== 'undefined';
 
 export default hasWindow;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,7 +9,8 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "baseUrl": "src",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["react/next", "react-dom/next"]
   },
   "includes": ["src", "global.d.ts", "custom.d.ts"]
 }


### PR DESCRIPTION
- [x] 🧪 테스트 전체를 실행해봤나요? 
- [x] 💯 테스트가 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 안쓰는 코드가 남아있지 않나요?
- [x] 🎟️ PR에 대한 이슈는 등록됐나요?
- [x] 🏷️ PR 라벨 등록 했나요?
- [x] 🍠 행복한 고구마인가요?

## 작업 내용
React Portal은 SSR에서 처리해주지 못하기 때문에 Snackbar Portal을 클라이언트에서 lazy loading 후 ssr false 옵션을 갖도록 수정 
([참고](https://spectrum.chat/react/general/has-anyone-successfully-implemented-portals-with-ssr~f6ca88b2-71e2-4814-86d3-1c206aab9636))

Closes #607 
