### PR TITLE
[FE] fix: 할로윈 테마 적용 범위를 react root로 수정

### DIFF
--- a/frontend/server/utils.tsx
+++ b/frontend/server/utils.tsx
@@ -62,7 +62,6 @@ export const generateResponse = async (
         suspense: true,
         useErrorBoundary: true,
         retry: 1,
-        staleTime: Infinity,
       },
     },
   });

--- a/frontend/src/Global.styles.ts
+++ b/frontend/src/Global.styles.ts
@@ -5,6 +5,9 @@ import { visuallyHidden } from 'commonStyles';
 const GlobalStyle = createGlobalStyle`  
   html, body {
     overflow: auto;
+  }
+  
+  #root {
     background: ${({ theme }) => theme.background};
     transition: background 0.2s ease;
   }

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -4,17 +4,17 @@ import { Link, NavLink } from 'react-router-dom';
 import Pencil from 'assets/pencil.svg';
 import Search from 'assets/search.svg';
 import SignIn from 'assets/signin.svg';
-import Page from 'pages';
 import LoginModal from 'components/LoginModal/LoginModal';
-import { PALETTE } from 'constants/palette';
-import ROUTE from 'constants/routes';
-import useModal from 'contexts/modal/useModal';
-import useMember from 'contexts/member/useMember';
-import { ButtonStyle } from 'types';
-import Styled, { Logo, LogoText, Searchbar } from './Header.styles';
 import IconButton from 'components/@common/IconButton/IconButton';
 import UserProfile from 'components/UserProfile/UserProfile';
+import { PALETTE } from 'constants/palette';
+import ROUTE from 'constants/routes';
 import useFocusOut from 'hooks/@common/useFocusOut';
+import useModal from 'contexts/modal/useModal';
+import useMember from 'contexts/member/useMember';
+import Page from 'pages';
+import { ButtonStyle } from 'types';
+import Styled, { Logo, LogoText, Searchbar } from './Header.styles';
 
 interface Props {
   isFolded?: boolean;


### PR DESCRIPTION
- [ ] 🧪 테스트 전체를 실행해봤나요? 
- [ ] 💯 테스트가 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 안쓰는 코드가 남아있지 않나요?
- [ ] 🎟️ PR에 대한 이슈는 등록됐나요?
- [x] 🏷️ PR 라벨 등록 했나요?
- [x] 🍠 행복한 고구마인가요?

## 작업 내용
미키가 전에 snackbar가 이상한 데 뜨는 이슈를 해결하면서 말했던,
`<div id="root"></div> 안에 있는 태그들만 babel-plugin-styled-components이 적용된다.`
는 문제가 여기서도 적용되는 게 아닐까 싶어서..!! 
`body`와 `html` 전체의 `background`에 적용되어 있던 `theme`을 `root`로 옮기면 될까 해서 PR 보내봅니당
