### PR TITLE
refactor: 댓글 삭제 로직 변경

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/admin/application/AdminService.java
+++ b/backend/src/main/java/com/wooteco/nolto/admin/application/AdminService.java
@@ -155,8 +155,7 @@ public class AdminService {
         if (findComment.isParentComment()) {
             applicationEventPublisher.publishEvent(new NotificationCommentDeleteEvent(findComment));
         }
-        User author = findComment.getAuthor();
-        author.deleteComment(findComment);
+        commentRepository.delete(findComment);
     }
 
     private Comment getComment(Long commentId) {

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
@@ -57,7 +57,7 @@ public class CommentService {
         if (findComment.isParentComment()) {
             applicationEventPublisher.publishEvent(new NotificationCommentDeleteEvent(findComment));
         }
-        user.deleteComment(findComment);
+        commentRepository.delete(findComment);
     }
 
     public CommentResponse createReply(User user, Long feedId, Long commentId, CommentRequest request) {

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
@@ -42,10 +42,10 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "parent_id")
     private Comment parentComment;
 
-    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE)
     private List<CommentLike> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.REMOVE)
     private List<Comment> replies = new ArrayList<>();
 
     public Comment(String content, boolean helper) {

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -55,10 +55,10 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Like> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<CommentLike> commentLikes = new ArrayList<>();
 
     public User(String socialId, SocialType socialType, String nickName, String imageUrl) {

--- a/backend/src/test/java/com/wooteco/nolto/admin/application/AdminServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/admin/application/AdminServiceTest.java
@@ -249,23 +249,25 @@ class AdminServiceTest {
     void deleteComment() {
         //given
         Feed 피드1 = 진행중_단계의_피드_생성("피드1", "피드1").writtenBy(조엘);
-        feedRepository.saveAndFlush(피드1);
+        feedRepository.save(피드1);
         Feed 피드2 = 진행중_단계의_피드_생성("피드2", "피드2").writtenBy(조엘);
-        feedRepository.saveAndFlush(피드2);
+        feedRepository.save(피드2);
         Feed 피드3 = 진행중_단계의_피드_생성("피드3", "피드3").writtenBy(조엘);
-        feedRepository.saveAndFlush(피드3);
+        feedRepository.save(피드3);
 
         final Comment 피드1_댓글1 = new Comment("피드1_댓글1", false).writtenBy(찰리, 피드1);
-        commentRepository.saveAndFlush(피드1_댓글1);
+        commentRepository.save(피드1_댓글1);
         final Comment 피드1_댓글2 = new Comment("피드1_댓글2", false).writtenBy(찰리, 피드1);
-        commentRepository.saveAndFlush(피드1_댓글2);
+        commentRepository.save(피드1_댓글2);
         final Comment 피드1_댓글3 = new Comment("피드1_댓글3", false).writtenBy(찰리, 피드1);
-        commentRepository.saveAndFlush(피드1_댓글3);
+        commentRepository.save(피드1_댓글3);
 
         final Comment 피드2_댓글1 = new Comment("피드2_댓글1", false).writtenBy(찰리, 피드2);
-        commentRepository.saveAndFlush(피드2_댓글1);
+        commentRepository.save(피드2_댓글1);
         final Comment 피드2_댓글2 = new Comment("피드2_댓글2", false).writtenBy(찰리, 피드2);
-        commentRepository.saveAndFlush(피드2_댓글2);
+        commentRepository.save(피드2_댓글2);
+        em.flush();
+        em.clear();
 
         //when
         adminService.deleteComment(User.ADMIN_USER, 피드1_댓글1.getId());

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
@@ -305,6 +305,7 @@ class CommentServiceTest extends CommentServiceFixture {
         assertThat(구글_유저.getComments().size()).isOne();
         assertThat(아마찌.getComments().size()).isOne();
         em.flush();
+        em.clear();
 
         // when
         Comment 아마찌_대댓글 = commentService.findEntityById(아마찌_대댓글_생성_응답.getId());
@@ -333,6 +334,7 @@ class CommentServiceTest extends CommentServiceFixture {
         commentLikeService.addCommentLike(포모_댓글_생성_응답.getId(), 구글_유저);
         commentLikeService.addCommentLike(아마찌_대댓글_생성_응답.getId(), 아마찌);
         em.flush();
+        em.clear();
 
         // when
         Comment 포모_댓글 = commentService.findEntityById(포모_댓글_생성_응답.getId());


### PR DESCRIPTION
- [x] 🧪 테스트 전체를 실행해봤나요? 
- [x] 💯 테스트가 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 안쓰는 코드가 남아있지 않나요?
- [ ] 🎟️ PR에 대한 이슈는 등록됐나요? => 지금 이 PR은 필수적인게 아니라서 우선 Issue는 등록 안해봅니당,,,
- [x] 🏷️ PR 라벨 등록 했나요?
- [x] 🍠 행복한 고구마인가요?

## 작업 내용
- **작업 동기**
    - 저번에 JPA에서 힘들었던 점 얘기하면서, 댓글 삭제 로직 얘기했었는데요. 
    - "User가 영속성 컨텍스트에 올라가있고, Reply를 삭제할라고 보니까, 연관 관계가 다수 얽혀있어 Reply가 제대로 삭제가 안되서 힘들었다" 라는 경험담을 이야기 했는데요
    - 그래서 JPA에서 힘들었던 점 떠올라서 코드보다가 이상하다... 🤔 싶어서 조금 고쳐봤습니다. 

- **이상한 점**
    - 현재 피드 삭제로직
    ```java
    public void delete(User user, Long feedId) {
        Feed findFeed = findEntityById(feedId);
        if (findFeed.notSameAuthor(user)) {
            throw new UnauthorizedException(ErrorType.UNAUTHORIZED_DELETE_FEED);
        }
        applicationEventPublisher.publishEvent(new NotificationFeedDeleteEvent(findFeed));
        feedRepository.delete(findFeed);
    }
    ```
    - 현재 댓글 삭제로직
    ```java
    public void deleteComment(User user, Long commentId) {
        Comment findComment = findEntityById(commentId);
        findComment.checkAuthority(user, ErrorType.UNAUTHORIZED_DELETE_COMMENT);
        if (findComment.isParentComment()) {
            applicationEventPublisher.publishEvent(new NotificationCommentDeleteEvent(findComment));
        }
        user.deleteComment(findComment);
    }
    ```
    - 피드랑 댓글 사실 엔티티 관계는 비슷하잖아요. Like 관계 중계 테이블에, User 작성자 있고, `List<Comment>` 있고 등등
    - 근데 피드는 feedRepository.delete()로 지워지고, 댓글은 user에서 직접 끊어줘야 하는게 이상했어요
    - 사실 DB 관점에서 바라봤을 때, 그냥 Comment의 튜플 하나 지우는 것은 어렵지 않잖아요?
    - 그래서 댓글 삭제 로직도 commentRepository.delete(findComment); 로 코드 변경하고 테스트 돌려봤습니다

- **그전에 또 하나 이상했던 것**
    - 또한 이상했던 것은, 서비스 단에서 파라미터로 넘겨받은 User는 ArgumentResolver에서 이미 추출된 User 객체인데, 
        - (그니까 ArgumentResolver에서 호출하고, DB 트랜잭션 열어서 조회해서 가져온 친구인데)
    - 서비스에서 새로운 트랜잭션이 열렸을때 User 객체가 영속성 컨텍스트의 관리 대상이 되는가 싶더라고요?
        - 같은 트랜잭션도 아닌데 말이죠... 이건 제가 JPA의 지식이 부족한 탓이 있는 것 같아요
            - 막 알아서 준영속에서 영속이 되는 건가... User 엔티티가 처리 로직중에 필요해지면...?
        - 우선 영속성 컨텍스트의 관리대상이 아마 되는것 같아요. 
            - user.deleteComment() 로직 진행해서 더티체크하고 반영되는 것 보면...

- **터지는 테스트들**
    - 공교롭게도 터지는 테스트들 (2개) 은 Reply와 관련된 것들이였는데요. 
    - 복잡한 관계들이 얽히고 섥혀있어 제대로 delete 쿼리가 안나가더라고요
    - 터지는 테스트들을 보니까 em.flush() 만 given절에서 해주고 있어서 em.clear() 까지 해줬습니다
        - 우리가 테스트코드 단에서 `@Transaction`을 붙여서 setUp 대상의 모든 객체들이 영속성 컨텍스트에 올라감
            - ReplyLike, `List<Reply>` 등 모든 잡다한 연관관계가 영속성 컨텍스트에서 관리됨
            - 아마 이래서 테스트 코드에서 제대로 삭제쿼리를 못보낸 거 아닐까 추측중 🤔
        - em.clear() 까지 해줘야 새로운 트랜잭션을 열어서 테스트코드 처리하지 않을까 생각했음
        - https://www.inflearn.com/questions/38169
    - 테스트가 돌아갔고, orphanRemoval 도 굳이 필요없지 않을까 싶어서 지워봤는데 테스트 코드 잘 돌아감
    - 어드민 관련 테스트도 터져서 살짝 손 봄

- **나의 결론**
    - 테스트코드에서 `@Transactional`을 붙인게 약간 적폐이지 않았나...