### PR TITLE
refactor: redis에서 refresh token 삭제 로직 추가

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/auth/application/AuthService.java
+++ b/backend/src/main/java/com/wooteco/nolto/auth/application/AuthService.java
@@ -108,6 +108,7 @@ public class AuthService {
 
         if (!redisRepository.leftPop(request.getRefreshToken()).equals(request.getClientIP())) {
             log.info("invalid request client ip for refresh token. request client : " + request.getClientIP());
+            redisRepository.delete(request.getRefreshToken());
             throw new UnauthorizedException(ErrorType.INVALID_CLIENT);
         }
 


### PR DESCRIPTION
- [x] 🧪 테스트 전체를 실행해봤나요? 
- [x] 💯 테스트가 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 안쓰는 코드가 남아있지 않나요?
- [x] 🎟️ PR에 대한 이슈는 등록됐나요?
- [x] 🏷️ PR 라벨 등록 했나요?
- [x] 🍠 행복한 고구마인가요?

## 작업 내용

- 탈취된 리프레시 토큰으로 요청이 들어오는 경우, 기존 리프레시 토큰을 레디스에서 삭제하는 로직이 추가가 안되어있어서 😥 수정합니다!
  - `탈취된 리프레시 토큰 요청 : 리프레시 토큰은 정상적으로 들어왔으나 ClientIP가 다른 경우`

