### PR TITLE
refactor: 불필요한 fetch join 제거

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/CommentRepository.java
@@ -11,7 +11,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("select distinct com " +
             "from Comment as com " +
-            "join fetch com.author " +
+            "join com.author " +
             "join fetch com.feed " +
             "left join fetch com.likes " +
             "where com.feed.id = :feedId and com.parentComment.id is null " +
@@ -20,7 +20,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("select distinct com " +
             "from Comment as com " +
-            "join fetch com.author " +
+            "join com.author " +
             "join fetch com.feed " +
             "left join fetch com.likes " +
             "where com.feed.id = :feedId and com.parentComment.id = :parentCommentId " +

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/FeedRepository.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/repository/FeedRepository.java
@@ -58,13 +58,13 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     @Query("select distinct feed " +
             "from Feed as feed " +
-            "join fetch feed.author " +
+            "join feed.author " +
             "left join fetch feed.feedTechs")
     List<Feed> findAllWithFetchJoin();
 
     @Query("select distinct feed " +
             "from Feed as feed " +
-            "join fetch feed.author " +
+            "join feed.author " +
             "join fetch feed.comments")
     List<Feed> findAllFeedsHavingComments();
 }


### PR DESCRIPTION
- [x] 🧪 테스트 전체를 실행해봤나요? 
- [x] 💯 테스트가 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 안쓰는 코드가 남아있지 않나요?
- [ ] 🎟️ PR에 대한 이슈는 등록됐나요?
- [x] 🏷️ PR 라벨 등록 했나요?
- [x] 🍠 행복한 고구마인가요?

## 작업 내용

- 불필요하게 fetch join하여 영속화되고 있는 엔티티를 제거해주었습니다.

  > 좀 더 상세히 설명하자면 우리 앞선 PR을 통해서 알다시피 이미 컨트롤러에서 OSIV를 통해 User가 영속화된 채로 들어오고 있고, 
  그 User를 그대로 사용하고 있어 select를 하는 경우에 User를 fetch join할 필요가 없습니다! 
- 간단한 기능이라 따로 이슈는 적지 않았습니다!
- 참고 : https://pomo0703.tistory.com/214


