### PR TITLE
refactor(user): 좋아요 취소 로직 변경 및 user cascade 옵션 변경

### DIFF
--- a/backend/src/main/java/com/wooteco/nolto/admin/application/AdminService.java
+++ b/backend/src/main/java/com/wooteco/nolto/admin/application/AdminService.java
@@ -155,8 +155,7 @@ public class AdminService {
         if (findComment.isParentComment()) {
             applicationEventPublisher.publishEvent(new NotificationCommentDeleteEvent(findComment));
         }
-        User author = findComment.getAuthor();
-        author.deleteComment(findComment);
+        commentRepository.delete(findComment);
     }
 
     private Comment getComment(Long commentId) {

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/CommentLikeService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/CommentLikeService.java
@@ -24,7 +24,6 @@ public class CommentLikeService {
             throw new BadRequestException(ErrorType.ALREADY_LIKED_COMMENT);
         }
         CommentLike commentLike = new CommentLike(user, findComment);
-        user.addCommentLike(commentLike);
         commentLikeRepository.save(commentLike);
     }
 
@@ -32,7 +31,6 @@ public class CommentLikeService {
         Comment findComment = commentService.findEntityById(commentId);
         CommentLike findCommentLike = findComment.findLikeBy(user)
                 .orElseThrow(() -> new BadRequestException(ErrorType.NOT_LIKED_COMMENT));
-        user.delete(findCommentLike);
         commentLikeRepository.delete(findCommentLike);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/CommentService.java
@@ -57,7 +57,7 @@ public class CommentService {
         if (findComment.isParentComment()) {
             applicationEventPublisher.publishEvent(new NotificationCommentDeleteEvent(findComment));
         }
-        user.deleteComment(findComment);
+        commentRepository.delete(findComment);
     }
 
     public CommentResponse createReply(User user, Long feedId, Long commentId, CommentRequest request) {

--- a/backend/src/main/java/com/wooteco/nolto/feed/application/LikeService.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/application/LikeService.java
@@ -27,7 +27,7 @@ public class LikeService {
         if (user.isLiked(findFeed)) {
             throw new BadRequestException(ErrorType.ALREADY_LIKED);
         }
-        user.addLike(new Like(user, findFeed));
+        likeRepository.save(new Like(user, findFeed));
         applicationEventPublisher.publishEvent(NotificationEvent.likeOf(findFeed, user));
     }
 
@@ -35,7 +35,6 @@ public class LikeService {
         Feed findFeed = feedService.findEntityById(feedId);
         Like findLike = findFeed.findLikeBy(user)
                 .orElseThrow(() -> new BadRequestException(ErrorType.NOT_LIKED));
-        user.delete(findLike);
         likeRepository.delete(findLike);
     }
 }

--- a/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
+++ b/backend/src/main/java/com/wooteco/nolto/feed/domain/Comment.java
@@ -42,10 +42,10 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "parent_id")
     private Comment parentComment;
 
-    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE)
     private List<CommentLike> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.REMOVE)
     private List<Comment> replies = new ArrayList<>();
 
     public Comment(String content, boolean helper) {

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -55,10 +55,10 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Like> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<CommentLike> commentLikes = new ArrayList<>();
 
     public User(String socialId, SocialType socialType, String nickName, String imageUrl) {

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -55,7 +55,7 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Like> likes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "author", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)

--- a/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
+++ b/backend/src/main/java/com/wooteco/nolto/user/domain/User.java
@@ -49,10 +49,10 @@ public class User extends BaseEntity {
 
     private String bio = "";
 
-    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "author", cascade = CascadeType.REMOVE)
     private List<Feed> feeds = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Like> likes = new ArrayList<>();
 
     @OneToMany(mappedBy = "author", cascade = CascadeType.REMOVE)

--- a/backend/src/test/java/com/wooteco/nolto/admin/application/AdminServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/admin/application/AdminServiceTest.java
@@ -249,23 +249,25 @@ class AdminServiceTest {
     void deleteComment() {
         //given
         Feed 피드1 = 진행중_단계의_피드_생성("피드1", "피드1").writtenBy(조엘);
-        feedRepository.saveAndFlush(피드1);
+        feedRepository.save(피드1);
         Feed 피드2 = 진행중_단계의_피드_생성("피드2", "피드2").writtenBy(조엘);
-        feedRepository.saveAndFlush(피드2);
+        feedRepository.save(피드2);
         Feed 피드3 = 진행중_단계의_피드_생성("피드3", "피드3").writtenBy(조엘);
-        feedRepository.saveAndFlush(피드3);
+        feedRepository.save(피드3);
 
         final Comment 피드1_댓글1 = new Comment("피드1_댓글1", false).writtenBy(찰리, 피드1);
-        commentRepository.saveAndFlush(피드1_댓글1);
+        commentRepository.save(피드1_댓글1);
         final Comment 피드1_댓글2 = new Comment("피드1_댓글2", false).writtenBy(찰리, 피드1);
-        commentRepository.saveAndFlush(피드1_댓글2);
+        commentRepository.save(피드1_댓글2);
         final Comment 피드1_댓글3 = new Comment("피드1_댓글3", false).writtenBy(찰리, 피드1);
-        commentRepository.saveAndFlush(피드1_댓글3);
+        commentRepository.save(피드1_댓글3);
 
         final Comment 피드2_댓글1 = new Comment("피드2_댓글1", false).writtenBy(찰리, 피드2);
-        commentRepository.saveAndFlush(피드2_댓글1);
+        commentRepository.save(피드2_댓글1);
         final Comment 피드2_댓글2 = new Comment("피드2_댓글2", false).writtenBy(찰리, 피드2);
-        commentRepository.saveAndFlush(피드2_댓글2);
+        commentRepository.save(피드2_댓글2);
+        em.flush();
+        em.clear();
 
         //when
         adminService.deleteComment(User.ADMIN_USER, 피드1_댓글1.getId());

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentLikeServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentLikeServiceTest.java
@@ -33,6 +33,7 @@ class CommentLikeServiceTest extends CommentServiceFixture {
         em.clear();
 
         // then
+        찰리가_쓴_피드에_찰리가_쓴_댓글 = commentRepository.getById(찰리가_쓴_피드에_찰리가_쓴_댓글.getId());
         assertThat(찰리가_쓴_피드에_찰리가_쓴_댓글.getLikes()).hasSize(1);
     }
 
@@ -46,6 +47,7 @@ class CommentLikeServiceTest extends CommentServiceFixture {
         em.clear();
 
         // when then
+        찰리 = userRepository.getById(찰리.getId());
         assertThatThrownBy(() -> commentLikeService.addCommentLike(찰리가_쓴_피드에_찰리가_쓴_댓글.getId(), 찰리))
                 .isInstanceOf(BadRequestException.class);
     }
@@ -76,7 +78,6 @@ class CommentLikeServiceTest extends CommentServiceFixture {
         commentLikeService.addCommentLike(찰리가_쓴_피드에_찰리가_쓴_댓글.getId(), 찰리);
         em.flush();
         em.clear();
-        assertThat(찰리가_쓴_피드에_찰리가_쓴_댓글.getLikes()).hasSize(1);
 
         // when
         Comment findComment1 = commentService.findEntityById(찰리가_쓴_피드에_찰리가_쓴_댓글.getId());
@@ -102,6 +103,7 @@ class CommentLikeServiceTest extends CommentServiceFixture {
         em.clear();
 
         // then
+        찰리가_쓴_피드에_찰리가_쓴_댓글에_포모가_쓴_대댓글 = commentRepository.getById(찰리가_쓴_피드에_찰리가_쓴_댓글에_포모가_쓴_대댓글.getId());
         assertThat(찰리가_쓴_피드에_찰리가_쓴_댓글에_포모가_쓴_대댓글.getLikes()).hasSize(1);
     }
 
@@ -115,6 +117,7 @@ class CommentLikeServiceTest extends CommentServiceFixture {
         em.clear();
 
         // when then
+        찰리 = userRepository.getById(찰리.getId());
         assertThatThrownBy(() -> commentLikeService.addCommentLike(찰리가_쓴_피드에_찰리가_쓴_댓글에_포모가_쓴_대댓글.getId(), 찰리))
                 .isInstanceOf(BadRequestException.class);
     }
@@ -145,7 +148,6 @@ class CommentLikeServiceTest extends CommentServiceFixture {
         commentLikeService.addCommentLike(찰리가_쓴_피드에_찰리가_쓴_댓글에_포모가_쓴_대댓글.getId(), 찰리);
         em.flush();
         em.clear();
-        assertThat(찰리가_쓴_피드에_찰리가_쓴_댓글에_포모가_쓴_대댓글.getLikes()).hasSize(1);
 
         // when
         Comment findComment1 = commentService.findEntityById(찰리가_쓴_피드에_찰리가_쓴_댓글에_포모가_쓴_대댓글.getId());

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
@@ -305,6 +305,7 @@ class CommentServiceTest extends CommentServiceFixture {
         assertThat(구글_유저.getComments().size()).isOne();
         assertThat(아마찌.getComments().size()).isOne();
         em.flush();
+        em.clear();
 
         // when
         Comment 아마찌_대댓글 = commentService.findEntityById(아마찌_대댓글_생성_응답.getId());
@@ -333,6 +334,7 @@ class CommentServiceTest extends CommentServiceFixture {
         commentLikeService.addCommentLike(포모_댓글_생성_응답.getId(), 구글_유저);
         commentLikeService.addCommentLike(아마찌_대댓글_생성_응답.getId(), 아마찌);
         em.flush();
+        em.clear();
 
         // when
         Comment 포모_댓글 = commentService.findEntityById(포모_댓글_생성_응답.getId());

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/CommentServiceTest.java
@@ -339,6 +339,8 @@ class CommentServiceTest extends CommentServiceFixture {
         // when
         Comment 포모_댓글 = commentService.findEntityById(포모_댓글_생성_응답.getId());
         Comment 아마찌_대댓글 = commentService.findEntityById(아마찌_대댓글_생성_응답.getId());
+        구글_유저 = userRepository.getById(구글_유저.getId());
+        아마찌 = userRepository.getById(아마찌.getId());
         assertThat(구글_유저.getComments().size()).isOne();
         assertThat(아마찌.getComments().size()).isOne();
         assertThat(구글_유저.getCommentLikes().size()).isOne();

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
@@ -1,14 +1,13 @@
 package com.wooteco.nolto.feed.application;
 
-import com.wooteco.nolto.admin.ui.dto.CommentsByFeedResponse;
 import com.wooteco.nolto.exception.ErrorType;
 import com.wooteco.nolto.exception.NotFoundException;
 import com.wooteco.nolto.exception.UnauthorizedException;
-import com.wooteco.nolto.feed.domain.Comment;
 import com.wooteco.nolto.feed.domain.Feed;
-import com.wooteco.nolto.feed.domain.repository.CommentRepository;
-import com.wooteco.nolto.feed.domain.repository.FeedRepository;
-import com.wooteco.nolto.feed.ui.dto.*;
+import com.wooteco.nolto.feed.ui.dto.FeedCardPaginationResponse;
+import com.wooteco.nolto.feed.ui.dto.FeedCardResponse;
+import com.wooteco.nolto.feed.ui.dto.FeedRequest;
+import com.wooteco.nolto.feed.ui.dto.FeedResponse;
 import com.wooteco.nolto.image.application.ImageService;
 import com.wooteco.nolto.tech.domain.Tech;
 import com.wooteco.nolto.tech.domain.TechRepository;
@@ -27,10 +26,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.wooteco.nolto.FeedFixture.진행중_단계의_피드_생성;
 import static com.wooteco.nolto.TechFixture.*;
 import static com.wooteco.nolto.UserFixture.조엘_생성;
 import static com.wooteco.nolto.UserFixture.찰리_생성;
@@ -280,9 +281,9 @@ class FeedServiceTest {
         likeService.addLike(조엘, feedId1);
         em.flush();
         em.clear();
+        조엘 = userRepository.getById(조엘.getId());
 
         // when
-        조엘 = userRepository.getById(조엘.getId());
         FeedResponse feedResponse = feedService.viewFeed(조엘, feedId1, true);
 
         // then
@@ -296,6 +297,7 @@ class FeedServiceTest {
         Long feedId1 = feedService.create(찰리, EMPTY_TECH_FEED_REQUEST);
         em.flush();
         em.clear();
+        조엘 = userRepository.getById(조엘.getId());
 
         // when
         FeedResponse feedResponse = feedService.viewFeed(조엘, feedId1, true);
@@ -317,6 +319,7 @@ class FeedServiceTest {
         likeService.deleteLike(조엘, feedId1);
         em.flush();
         em.clear();
+        조엘 = userRepository.getById(조엘.getId());
         FeedResponse feedResponse = feedService.viewFeed(조엘, feedId1, true);
 
         // then

--- a/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
+++ b/backend/src/test/java/com/wooteco/nolto/feed/application/FeedServiceTest.java
@@ -282,6 +282,7 @@ class FeedServiceTest {
         em.clear();
 
         // when
+        조엘 = userRepository.getById(조엘.getId());
         FeedResponse feedResponse = feedService.viewFeed(조엘, feedId1, true);
 
         // then
@@ -332,12 +333,15 @@ class FeedServiceTest {
         em.clear();
 
         // when
+        조엘 = userRepository.getById(조엘.getId());
         userRepository.delete(조엘);
         em.flush();
         em.clear();
         Feed findFeed = feedService.findEntityById(feedId1);
 
         // then
+        조엘 = userRepository.getById(조엘.getId());
+
         assertThat(findFeed.findLikeBy(조엘)).isEmpty();
     }
 


### PR DESCRIPTION
- [x] 🧪 테스트 전체를 실행해봤나요? 
- [x] 💯 테스트가 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 안쓰는 코드가 남아있지 않나요?
- [ ] 🎟️ PR에 대한 이슈는 등록됐나요?
- [x] 🏷️ PR 라벨 등록 했나요?
- [x] 🍠 행복한 고구마인가요?

## 작업 내용

_베이스는 #694로 해당 pr에 다 설명하기는 좀 구구절절이라 체리픽해서 작성했습니다_

**1. user에 있는 feeds, likes에 있는 cascade 옵션을 remove로 변경**
놀토에서 user가 생성될 때 feed와 like가 함께 생성되는 경우는 없고 
원하는 것은 유저가 삭제될 때 feed와 like가 삭제되는 것이니 comments, commentsLikes에 
cascade.remove만 걸어준 옵션을 동일하게 가져갈 수 있을 것 같습니다 !

**2. 각 likeService에 있는 user.addLike~와 같은 로직 삭제** 
#694에서 논의한 것 처럼 댓글 삭제를 이제 
`서비스의 역할에서 영속화 된 데이터를 지운다라는 측면에서 바라봄, 연관관계를 끊어서 삭제가 아닌 직접 삭제`로 
repository로 삭제하는 로직을 가져간다면, 이를 피드 좋아요와 댓글 좋아요에도 동일히 적용해 보는 것은 으떨까요?
이렇게 되면 기존 likeService에서 추가는 user.addLike로 추가, 삭제는 repository로 직접 삭제로 
서로 달랐던 구현방식을 일관성있게 가져갈 수 있을 것 같습니다.(commentLikeService랑두요!)

이 두 사항을 반영하면 터지는 테스트 코드들이 있는데, 이는 프로덕션 로직이 잘못된 것이 아니라
em.clear()로 영속성 컨텍스트를 비우고
검증에 사용할 대상 객체들을 db에서 새롭게 조회하지 않고 영속화 되지 않은 객체를 사용해서 발생하는 문제였습니다 😅


## 주의사항
- 요런식으로 무작정 사용했던 cascade.all을 개선할 수 있을 것 같다는 생각 공유 차원 
- #694를 체리픽해왔기에 이 pr이 머지되어도 충돌은 안날겝니당
