### PR TITLE
feat(log4j2): 구 버전의 보안 이슈로 log4j2 버전 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -75,6 +75,9 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //log4j2
+    implementation 'org.apache.logging.log4j:log4j-api:2.15.0'
 }
 
 ext {


### PR DESCRIPTION
2.14.1 -> 2.15.0

- [x] 🧪 테스트 전체를 실행해봤나요? 
- [x] 💯 테스트가 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 안쓰는 코드가 남아있지 않나요?
- [x] 🎟️ PR에 대한 이슈는 등록됐나요?
- [x] 🏷️ PR 라벨 등록 했나요?
- [x] 🍠 행복한 고구마인가요?

## 작업 내용

실제 사용은 안하고 있지만 내부에 log4j2 라이브러리가 포함되어 있어(slf4j로 추정됨)

해당 버전이 2.14.1 버전이라 보안 이슈가 터진 버전으로 확인되어 2.15.1 버전으로 변경

![image](https://user-images.githubusercontent.com/57378410/145696754-10c35950-09bc-4dd4-8235-2dcbdbde9376.png)

Closes #702 

## 주의사항
apache 주의 해주세요